### PR TITLE
fix(agentdb): harden deployment selection and message UX

### DIFF
--- a/sidecar/internal/agentdb/schema.go
+++ b/sidecar/internal/agentdb/schema.go
@@ -26,10 +26,6 @@ func (s *Store) Ensure(ctx context.Context) error {
 	return s.seedDefaultSizeProfiles(ctx)
 }
 
-func (s *Store) ensure(ctx context.Context) error {
-	return s.Ensure(ctx)
-}
-
 func (s *Store) ProvisionSchema(
 	ctx context.Context,
 	req RegisterRequest,

--- a/sidecar/web/e2e/agentdb-fixtures.ts
+++ b/sidecar/web/e2e/agentdb-fixtures.ts
@@ -320,11 +320,13 @@ export async function registerAgentDBAPIs(
   await page.route('**/api/v1/agent-dbs**', route => {
     const url = route.request().url()
     const method = route.request().method()
-    const deploymentMatch = url.match(/\/api\/v1\/agent-dbs\/([^/]+)$/)
-    if (method === 'DELETE' && deploymentMatch) {
-      const id = decodeURIComponent(deploymentMatch[1])
-      state.deployments = state.deployments.filter(dep =>
-        dep.deployment_id !== id)
+    const deploymentMatch = url.match(/\/api\/v1\/agent-dbs\/([^/]+?)(?:\?.*)?$/)
+    if (method === 'DELETE') {
+      if (deploymentMatch) {
+        const id = decodeURIComponent(deploymentMatch[1])
+        state.deployments = state.deployments.filter(dep =>
+          dep.deployment_id !== id)
+      }
       return route.fulfill({ status: 200, json: { deleted: true } })
     }
     if (url.includes('/providers')) {

--- a/sidecar/web/src/pages/AgentDBsPage.jsx
+++ b/sidecar/web/src/pages/AgentDBsPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Archive, RefreshCw } from 'lucide-react'
 import { useAPI } from '../hooks/useAPI'
 import { LoadingSpinner } from '../components/LoadingSpinner'
@@ -7,6 +7,10 @@ import { SummaryRow } from './agentdb/AgentDBSections'
 import { AgentDBWorkspaceTabs } from './agentdb/AgentDBWorkspaceTabs'
 import { AgentDBWorkspace } from './agentdb/AgentDBWorkspace'
 import { useAgentDBDetail } from './agentdb/useAgentDBDetail'
+
+// How many deployment refetches to wait for an optimistic selection to appear
+// before falling back to the first available deployment.
+const PENDING_SELECTION_MAX_REFRESHES = 2
 
 const initialForm = {
   tenant_id: 'tenant_agent',
@@ -176,6 +180,8 @@ export function AgentDBsPage() {
     [blueprintsAPI.data],
   )
 
+  const pendingWaitRef = useRef(0)
+
   useEffect(() => {
     if (deployments.length === 0) {
       if (selectedID) setSelectedID(null)
@@ -187,16 +193,29 @@ export function AgentDBsPage() {
       if (pendingSelectionID === selectedID) setPendingSelectionID(null)
       return
     }
-    if (selectedID && selectedID === pendingSelectionID) return
-    if (!selectedID || !selectedExists) {
-      setSelectedID(deployments[0].deployment_id)
+    // The selected deployment is not in the list. If it is an optimistic
+    // pending selection, wait a bounded number of refetches for it to land so
+    // a backend that never returns the new deployment can't pin us to a
+    // non-existent row indefinitely.
+    if (selectedID && selectedID === pendingSelectionID) {
+      pendingWaitRef.current += 1
+      if (pendingWaitRef.current <= PENDING_SELECTION_MAX_REFRESHES) return
+      setPendingSelectionID(null)
     }
+    setSelectedID(deployments[0].deployment_id)
   }, [deployments, pendingSelectionID, selectedID])
 
   const selected = deployments.find(d => d.deployment_id === selectedID)
   const detail = useAgentDBDetail(selectedID)
 
   const summary = useMemo(() => summarize(deployments), [deployments])
+
+  // Only surface the "View details" jump while its deployment is reachable —
+  // either already in the list or still pending its first appearance.
+  const messageTarget = messageDeploymentID && (
+    deployments.some(d => d.deployment_id === messageDeploymentID) ||
+    messageDeploymentID === pendingSelectionID
+  ) ? messageDeploymentID : null
 
   function clearStatus() {
     setError(null)
@@ -210,6 +229,7 @@ export function AgentDBsPage() {
   }
 
   function focusDeployment(id) {
+    pendingWaitRef.current = 0
     setPendingSelectionID(id)
     setSelectedID(id)
     setActiveTab('deployments')
@@ -223,7 +243,7 @@ export function AgentDBsPage() {
   }
 
   function viewMessageDeployment() {
-    if (messageDeploymentID) focusDeployment(messageDeploymentID)
+    if (messageTarget) focusDeployment(messageTarget)
   }
 
   async function refreshAll() {
@@ -712,7 +732,7 @@ export function AgentDBsPage() {
             background: 'rgba(52,211,153,0.08)',
           }}>
           <span>{message}</span>
-          {messageDeploymentID && (
+          {messageTarget && (
             <button type="button"
               data-testid="agent-db-view-deployment"
               onClick={viewMessageDeployment}

--- a/sidecar/web/src/pages/agentdb/AgentDBWorkspace.jsx
+++ b/sidecar/web/src/pages/agentdb/AgentDBWorkspace.jsx
@@ -206,8 +206,14 @@ function DeploymentsTab({
   onRequestDeployReview,
 }) {
   const detailRef = useRef(null)
+  const lastFocusKeyRef = useRef(0)
 
   useEffect(() => {
+    // Only scroll/focus on an explicit selection or focus action (which bumps
+    // detailFocusKey). Auto-reselection after a delete changes selectedID
+    // without bumping the key and must not steal focus or move the viewport.
+    if (lastFocusKeyRef.current === detailFocusKey) return
+    lastFocusKeyRef.current = detailFocusKey
     if (!detailFocusKey || !selectedID || !detailRef.current) return
     if (typeof detailRef.current.scrollIntoView === 'function') {
       detailRef.current.scrollIntoView({ block: 'start', behavior: 'smooth' })


### PR DESCRIPTION
## Summary

Follow-up hardening on the agent-DB QA release flows, fixing five robustness/UX issues surfaced by a max-effort review of the previous commit. No high-severity correctness bugs were found in that commit; these are the low-severity edges it left open.

## Fixes

1. **Stuck optimistic selection** — after provisioning, the UI optimistically selects the new deployment id and waited for it to appear in the list. If the backend never returned it (pagination / eventual consistency), `pendingSelectionID`/`selectedID` stayed pinned to a non-existent row forever and the detail pane was stuck on "No deployment selected". The wait is now bounded (`PENDING_SELECTION_MAX_REFRESHES`); after that it falls back to the first available deployment.

2. **Focus-steal on auto-reselect** — the detail pane's scroll/focus effect depended on `selectedID`, so auto-reselection after a delete (which doesn't bump `detailFocusKey`) yanked focus and smooth-scrolled the viewport. It now fires only when `detailFocusKey` actually changes, i.e. on an explicit selection or focus action.

3. **Stale "View details" jump** — `messageDeploymentID` wasn't invalidated when its deployment was deleted/archived, so the success-banner button led to an empty detail pane. The button now derives a `messageTarget` that's only shown while the deployment is reachable (present in the list, or still in its pending-appearance window).

4. **e2e DELETE fixture narrowing** — the previous change only handled DELETEs matching `/agent-dbs/<id>$`, silently routing any other DELETE to the catch-all (returning a deployments list instead of `{deleted:true}`). Broad DELETE handling is restored, query strings are tolerated, and matching ids still mutate fixture state.

5. **Cleanup** — removed the redundant always-true fallback condition in the selection effect.

## Verification

- `vitest run src/pages/AgentDBsPage.test.jsx` — 18/18 pass
- `eslint` on changed JSX — clean
- `go build` / `go vet ./internal/agentdb/...` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKzpD5LbECzKBenTN6K9Br)_