### PR TITLE
fix: stop recording pg_sage's own queries in pg_stat_statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ sidecar/cmd/create_admin_alloydb/
 # the pg17+pg_hint_plan Docker image at sidecar/test/hint_verify/Dockerfile).
 __pycache__/
 *.pyc
+DECISIONS.md
+REENTRY.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,12 @@
 
 ### Changed
 
-- **Self-monitoring:** every query pg_sage issues now carries a `/* pg_sage */`
-  marker, so the self-monitoring filter excludes them from analysis and they
-  are identifiable (not anonymous noise) in `pg_stat_statements`.
+- **Self-monitoring:** pg_sage now sets `pg_stat_statements.track = none` on
+  its own connections (best-effort, superuser only), so its monitoring queries
+  are never recorded and no longer pollute the user's `pg_stat_statements`. As
+  a fallback for restricted roles, every query pg_sage issues also carries a
+  `/* pg_sage */` marker and the self-monitoring filter excludes both the
+  marker and any `sage.`-schema query from analysis.
 - `isThinkingModel` now covers the `gemini-3.x` series (reserves output-token
   budget for thinking models, e.g. `gemini-3.5-flash`).
 

--- a/sidecar/cmd/pg_sage_sidecar/main.go
+++ b/sidecar/cmd/pg_sage_sidecar/main.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/pg-sage/sidecar/internal/advisor"
@@ -925,6 +926,12 @@ func initFleetMultiDB() {
 			poolCfg.ConnConfig.RuntimeParams = map[string]string{}
 		}
 		poolCfg.ConnConfig.RuntimeParams["application_name"] = "pg_sage"
+		// Keep pg_sage's own monitoring queries out of pg_stat_statements so
+		// they never pollute the user's workload stats. Best-effort — requires
+		// a role allowed to set the GUC (superuser / rds_superuser); silently
+		// ignored otherwise, where the /* pg_sage */ tag + self-monitoring
+		// filter remain as a fallback.
+		poolCfg.AfterConnect = silenceSelfStats
 
 		dbPool, err := pgxpool.NewWithConfig(
 			context.Background(), poolCfg)
@@ -1681,6 +1688,15 @@ func buildDBConfig(name string) config.DatabaseConfig {
 // resolveExecutionMode returns the execution mode from config.
 // Standalone mode defaults to "auto"; fleet databases have their
 // own execution_mode per database record.
+// silenceSelfStats stops pg_stat_statements from recording pg_sage's own
+// monitoring queries on this connection. Best-effort: failures (e.g. a
+// non-superuser role on a managed provider) are ignored, leaving the
+// /* pg_sage */ query tag and self-monitoring filter as the fallback.
+func silenceSelfStats(ctx context.Context, c *pgx.Conn) error {
+	_, _ = c.Exec(ctx, "SET pg_stat_statements.track = 'none'")
+	return nil
+}
+
 func resolveExecutionMode() string {
 	if len(cfg.Databases) > 0 {
 		// Use first database's config if available.

--- a/sidecar/cmd/pg_sage_sidecar/metadb.go
+++ b/sidecar/cmd/pg_sage_sidecar/metadb.go
@@ -47,6 +47,7 @@ func connectMetaDB(dsn string) (*pgxpool.Pool, error) {
 	poolCfg.MinConns = 1
 	poolCfg.MaxConnLifetime = 30 * time.Minute
 	poolCfg.MaxConnIdleTime = 5 * time.Minute
+	poolCfg.AfterConnect = silenceSelfStats
 
 	const maxAttempts = 5
 	backoff := 1 * time.Second
@@ -226,6 +227,7 @@ func connectMonitoredDB(
 		poolCfg.ConnConfig.RuntimeParams = map[string]string{}
 	}
 	poolCfg.ConnConfig.RuntimeParams["application_name"] = "pg_sage"
+	poolCfg.AfterConnect = silenceSelfStats
 
 	const maxAttempts = 5
 	backoff := 1 * time.Second


### PR DESCRIPTION
Sets `pg_stat_statements.track = none` on every pg_sage pool connection (standalone, fleet, meta-db) via an `AfterConnect` hook, so pg_sage's monitoring queries are never recorded and stop polluting the user's `pg_stat_statements`. Best-effort — silently ignored for roles that can't set the GUC, where the `/* pg_sage */` query tag + self-monitoring filter remain as the fallback.

**Verified live:** 0 pg_sage queries recorded after a reset + several cycles, with 6 active pg_sage backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)