### PR TITLE
fix(cases): stop surfacing pg_sage's own queries as Cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@
 
 - **Retention:** `cleanStaleFirstSeen` no longer skips stale-key cleanup when
   the index snapshot is empty (a regression from an over-broad safety guard).
+- **Cases:** pg_sage no longer surfaces its own monitoring queries as Cases.
+  The case projection now skips self-monitoring findings, and detection
+  recognizes pg_sage's statistics-catalog reads (`pg_stat_statements`,
+  `pg_stat_user_tables`, etc.) even in historical findings captured before
+  queries were tagged.
 
 ## v1.1 (2026-05-10) -- AgentDB Cloud Provisioning Release
 

--- a/sidecar/internal/api/cases_handlers.go
+++ b/sidecar/internal/api/cases_handlers.go
@@ -98,6 +98,18 @@ func queryProjectedCases(
 		selectedCases := make([]cases.Case, 0, len(rows))
 		findingIDs := make([]int, 0, len(rows))
 		for _, row := range rows {
+			// Never surface pg_sage's own monitoring queries as cases —
+			// including historical findings captured before queries were
+			// tagged (recognized by their catalog-read signature).
+			if selfmonitor.IsFinding(selfmonitor.FindingFields{
+				ObjectIdentifier: stringValue(row["object_identifier"]),
+				Title:            stringValue(row["title"]),
+				Detail:           detailMap(row["detail"]),
+				RecommendedSQL:   stringValue(row["recommended_sql"]),
+				RollbackSQL:      stringValue(row["rollback_sql"]),
+			}) {
+				continue
+			}
 			projected := cases.ProjectFinding(sourceFindingFromMap(row))
 			enrichCaseActionPolicies(&projected, mgr, selected.name)
 			if id, ok := caseFindingID(projected); ok {

--- a/sidecar/internal/selfmonitor/catalog_reader_test.go
+++ b/sidecar/internal/selfmonitor/catalog_reader_test.go
@@ -1,0 +1,32 @@
+package selfmonitor
+
+import "testing"
+
+// TestIsQueryText_CollectorCatalogReaders covers detection of pg_sage's own
+// statistics-catalog reads that carry no /* pg_sage */ tag and no sage.
+// schema reference (historical findings captured before tagging).
+func TestIsQueryText_CollectorCatalogReaders(t *testing.T) {
+	selfQueries := []string{
+		"SELECT COALESCE(queryid, $1), query, calls FROM pg_stat_statements WHERE dbid = (SELECT oid FROM pg_database WHERE datname = current_database())",
+		"SELECT schemaname, relname FROM pg_stat_user_tables WHERE n_dead_tup > 0",
+		"SELECT indexrelname FROM pg_stat_user_indexes",
+		"SELECT state, count(*) FROM pg_stat_activity GROUP BY state",
+		"select * from pg_stat_replication",
+	}
+	for _, q := range selfQueries {
+		if !IsQueryText(q) {
+			t.Errorf("expected self-monitoring detection for: %.60s", q)
+		}
+	}
+	// A user's application query that does NOT read pg_sage's catalogs.
+	userQueries := []string{
+		"SELECT id, name FROM public.customers WHERE active = true",
+		"UPDATE orders SET status = 'shipped' WHERE id = $1",
+		"SELECT count(*) FROM events WHERE created_at > now() - interval '1 day'",
+	}
+	for _, q := range userQueries {
+		if IsQueryText(q) {
+			t.Errorf("false positive on user query: %.60s", q)
+		}
+	}
+}

--- a/sidecar/internal/selfmonitor/selfmonitor.go
+++ b/sidecar/internal/selfmonitor/selfmonitor.go
@@ -15,6 +15,15 @@ const QueryTextSQLRegex = `(^|[^[:alnum:]_])("?sage"?)[[:space:]]*\.`
 
 var sageSchemaRef = regexp.MustCompile(`(?i)(^|[^a-z0-9_])("?sage"?)[[:space:]]*\.`)
 
+// collectorCatalogRef matches pg_sage's own monitoring reads of the
+// statistics catalogs. Historical findings captured before queries were
+// tagged with /* pg_sage */ carry no marker and never reference the sage
+// schema, so this signature is needed to recognize them as self-queries.
+var collectorCatalogRef = regexp.MustCompile(
+	`(?is)\bfrom[[:space:]]+(pg_stat_statements|pg_stat_user_tables|` +
+		`pg_stat_user_indexes|pg_stat_activity|pg_stat_database|` +
+		`pg_stat_replication|pg_stat_bgwriter|pg_stat_checkpointer)\b`)
+
 type FindingFields struct {
 	ObjectIdentifier string
 	Title            string
@@ -30,7 +39,8 @@ func IsQueryText(query string) bool {
 	}
 	lower := strings.ToLower(query)
 	return strings.Contains(lower, ApplicationName) ||
-		sageSchemaRef.MatchString(query)
+		sageSchemaRef.MatchString(query) ||
+		collectorCatalogRef.MatchString(query)
 }
 
 func IsObjectIdentifier(identifier string) bool {


### PR DESCRIPTION
Self-monitoring findings (pg_sage analyzing its own collector queries, captured before queries were tagged) were projecting into the Cases UI as "investigate query" cases — e.g. an EXPLAIN of pg_sage's own `pg_stat_statements` reader.

- The case projection now skips `selfmonitor.IsFinding` findings across every fleet DB pool.
- `selfmonitor` detection now recognizes pg_sage's statistics-catalog reads (`pg_stat_statements`, `pg_stat_user_tables`, etc.) which carry no `/* pg_sage */` marker in historical findings.
- Existing open self-monitoring findings on the live fleet were suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)