### PR TITLE
fix: stop emitting dangerous/noisy DBA recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,18 @@
   recognizes pg_sage's statistics-catalog reads (`pg_stat_statements`,
   `pg_stat_user_tables`, etc.) even in historical findings captured before
   queries were tagged.
+- **Recommendation quality:**
+  - The connection advisor now sizes `max_connections` against *total* (open)
+    backends, not just active ones, with a hard deterministic floor — it can
+    no longer recommend a value below current usage (previously it could
+    suggest `max_connections = 20` on a database with 28 open connections).
+  - Index rules (unused / duplicate / subset / missing-FK) now skip system and
+    extension-internal schemas (`pg_*`, `information_schema`, `_timescaledb_*`),
+    so pg_sage no longer recommends dropping or creating indexes it has no
+    business touching (e.g. `_timescaledb_catalog` indexes).
+  - Subset-index detection now also requires the superset to serve the subset's
+    `INCLUDE` columns, so an index supporting an index-only scan isn't flagged
+    as redundant.
 
 ## v1.1 (2026-05-10) -- AgentDB Cloud Provisioning Release
 

--- a/local_monitor_config.yaml
+++ b/local_monitor_config.yaml
@@ -6,7 +6,7 @@ mode: fleet
 defaults:
   max_connections: 2
   trust_level: observation
-  execution_mode: manual
+  execution_mode: auto
   collector_interval_seconds: 30
   analyzer_interval_seconds: 60
 

--- a/sidecar/internal/advisor/connection.go
+++ b/sidecar/internal/advisor/connection.go
@@ -3,6 +3,7 @@ package advisor
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/pg-sage/sidecar/internal/analyzer"
@@ -16,12 +17,18 @@ const connectionSystemPrompt = `You are a PostgreSQL connection management exper
 CRITICAL: Respond with ONLY a JSON array. No thinking, no reasoning outside JSON.
 
 RULES:
-1. If max_connections > 4x peak active, recommend reducing.
-2. If new connections/minute > 10 with short duration, recommend PgBouncer.
-3. If idle_in_transaction > 60s average, recommend ` +
+1. max_connections caps the number of OPEN connections (active AND idle),
+   not just active ones. Size every recommendation against TOTAL backends.
+   NEVER size against active-only counts.
+2. Only recommend reducing max_connections if it exceeds ~4x the peak TOTAL
+   connections AND there is comfortable headroom; reduce conservatively.
+3. NEVER recommend max_connections below
+   max(current total backends, peak total backends) + superuser_reserved_connections
+   + a safety margin of at least 10. Cutting below current usage rejects live
+   connections — this is a hard rule.
+4. If new connections/minute > 10 with short duration, recommend PgBouncer.
+5. If idle_in_transaction > 60s average, recommend ` +
 	`idle_in_transaction_session_timeout.
-4. Calculate memory savings from reducing max_connections.
-5. Never recommend max_connections below (peak_active * 1.5 + reserved + 5).
 6. If a pooler is detected (from application_name), don't recommend adding one.
 7. Recommend specific timeout values.
 8. If everything is healthy (utilization < 50%, no long idle tx), return [].
@@ -100,5 +107,64 @@ func analyzeConnections(
 		return nil, fmt.Errorf("connection LLM: %w", err)
 	}
 
-	return parseLLMFindings(resp, "connection_tuning", logFn), nil
+	findings := parseLLMFindings(resp, "connection_tuning", logFn)
+	return filterUnsafeMaxConnections(findings, sys, logFn), nil
+}
+
+// filterUnsafeMaxConnections drops any recommendation that would set
+// max_connections below the number of connections already open (plus
+// reserved slots and a safety margin). The LLM is instructed to size
+// against total backends, but this is the hard deterministic backstop:
+// cutting below current usage would reject live connections.
+func filterUnsafeMaxConnections(
+	findings []analyzer.Finding,
+	sys collector.SystemStats,
+	logFn func(string, string, ...any),
+) []analyzer.Finding {
+	// superuser_reserved_connections defaults to 3; the margin covers it
+	// plus headroom for spikes and pg_sage's own pool.
+	const reservedAndMargin = 13
+	floor := sys.TotalBackends + reservedAndMargin
+	out := findings[:0]
+	for _, f := range findings {
+		if n, ok := parseMaxConnectionsTarget(f.RecommendedSQL); ok && n < floor {
+			if logFn != nil {
+				logFn("advisor",
+					"rejecting max_connections=%d: below safe floor %d "+
+						"(total backends %d + reserved/margin %d)",
+					n, floor, sys.TotalBackends, reservedAndMargin)
+			}
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+// parseMaxConnectionsTarget extracts N from an
+// "ALTER SYSTEM SET max_connections = N" statement.
+func parseMaxConnectionsTarget(sql string) (int, bool) {
+	low := strings.ToLower(sql)
+	i := strings.Index(low, "max_connections")
+	if i < 0 {
+		return 0, false
+	}
+	rest := sql[i+len("max_connections"):]
+	rest = strings.TrimLeft(rest, " \t=")
+	rest = strings.Trim(strings.TrimSpace(rest), "'\";")
+	digits := strings.Builder{}
+	for _, r := range rest {
+		if r < '0' || r > '9' {
+			break
+		}
+		digits.WriteRune(r)
+	}
+	if digits.Len() == 0 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(digits.String())
+	if err != nil {
+		return 0, false
+	}
+	return n, true
 }

--- a/sidecar/internal/advisor/maxconn_floor_test.go
+++ b/sidecar/internal/advisor/maxconn_floor_test.go
@@ -1,0 +1,42 @@
+package advisor
+
+import (
+	"testing"
+
+	"github.com/pg-sage/sidecar/internal/analyzer"
+	"github.com/pg-sage/sidecar/internal/collector"
+)
+
+func TestParseMaxConnectionsTarget(t *testing.T) {
+	cases := map[string]int{
+		"ALTER SYSTEM SET max_connections = 30;":   30,
+		"ALTER SYSTEM SET max_connections = '20';": 20,
+		"alter system set max_connections=100":     100,
+	}
+	for sql, want := range cases {
+		if n, ok := parseMaxConnectionsTarget(sql); !ok || n != want {
+			t.Errorf("parse(%q) = %d,%v want %d", sql, n, ok, want)
+		}
+	}
+	if _, ok := parseMaxConnectionsTarget("ALTER SYSTEM SET work_mem = '16MB';"); ok {
+		t.Error("non-max_connections SQL should not parse")
+	}
+}
+
+func TestFilterUnsafeMaxConnections(t *testing.T) {
+	sys := collector.SystemStats{TotalBackends: 28} // floor = 28+13 = 41
+	in := []analyzer.Finding{
+		{Category: "connection_tuning", RecommendedSQL: "ALTER SYSTEM SET max_connections = 20;"},  // unsafe (< 41)
+		{Category: "connection_tuning", RecommendedSQL: "ALTER SYSTEM SET max_connections = 100;"},  // ok
+		{Category: "connection_tuning", RecommendedSQL: "ALTER SYSTEM SET idle_in_transaction_session_timeout = '60s';"}, // unrelated
+	}
+	out := filterUnsafeMaxConnections(in, sys, nil)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 findings after filtering the unsafe one, got %d", len(out))
+	}
+	for _, f := range out {
+		if n, ok := parseMaxConnectionsTarget(f.RecommendedSQL); ok && n < 41 {
+			t.Errorf("unsafe max_connections=%d survived the filter", n)
+		}
+	}
+}

--- a/sidecar/internal/analyzer/index_parser.go
+++ b/sidecar/internal/analyzer/index_parser.go
@@ -123,5 +123,20 @@ func IsSubset(a, b ParsedIndex) bool {
 			return false
 		}
 	}
+	// a's INCLUDE columns must also be served by b (as a key or INCLUDE
+	// column); otherwise a supports index-only scans that b does not, and
+	// dropping a would regress those queries.
+	bServes := make(map[string]bool, len(b.Columns)+len(b.IncludeCols))
+	for _, c := range b.Columns {
+		bServes[c] = true
+	}
+	for _, c := range b.IncludeCols {
+		bServes[c] = true
+	}
+	for _, c := range a.IncludeCols {
+		if !bServes[c] {
+			return false
+		}
+	}
 	return true
 }

--- a/sidecar/internal/analyzer/rules_index.go
+++ b/sidecar/internal/analyzer/rules_index.go
@@ -11,6 +11,19 @@ import (
 
 type tableKey struct{ schema, table string }
 
+// isSystemSchema reports whether a schema is owned by PostgreSQL or an
+// extension and must not be the target of index recommendations. The
+// executor protects these from execution, but findings about them should
+// never be generated in the first place (they are noise the user can do
+// nothing about, e.g. _timescaledb_catalog indexes).
+func isSystemSchema(schema string) bool {
+	s := strings.ToLower(schema)
+	return s == "information_schema" ||
+		s == "google_ml" ||
+		strings.HasPrefix(s, "pg_") ||
+		strings.HasPrefix(s, "_timescaledb")
+}
+
 // buildUnloggedSet returns a set of "schema.table" keys for unlogged
 // tables. Indexes on unlogged tables are lost on crash, so findings
 // about them should be downgraded to informational.
@@ -62,6 +75,9 @@ func ruleUnusedIndexes(
 	var findings []Finding
 
 	for _, idx := range current.Indexes {
+		if isSystemSchema(idx.SchemaName) {
+			continue
+		}
 		if idx.IdxScan > 0 || idx.IsPrimary || idx.IsUnique || !idx.IsValid {
 			continue
 		}
@@ -132,6 +148,9 @@ func ruleInvalidIndexes(
 	unlogged := buildUnloggedSet(current)
 	var findings []Finding
 	for _, idx := range current.Indexes {
+		if isSystemSchema(idx.SchemaName) {
+			continue
+		}
 		if idx.IsValid {
 			continue
 		}
@@ -181,6 +200,9 @@ func ruleDuplicateIndexes(
 ) []Finding {
 	var btrees []duplicateIndexCandidate
 	for _, idx := range current.Indexes {
+		if isSystemSchema(idx.SchemaName) {
+			continue
+		}
 		if !idx.IsValid {
 			continue
 		}
@@ -326,6 +348,9 @@ func ruleMissingFKIndexes(
 	indexed := make(map[tableKey][][]string)
 
 	for _, idx := range current.Indexes {
+		if isSystemSchema(idx.SchemaName) {
+			continue
+		}
 		if !idx.IsValid {
 			continue
 		}
@@ -347,6 +372,9 @@ func ruleMissingFKIndexes(
 				schema = t.SchemaName
 				break
 			}
+		}
+		if isSystemSchema(schema) {
+			continue
 		}
 
 		key := tableKey{schema, fk.TableName}

--- a/sidecar/internal/analyzer/schema_exclusion_test.go
+++ b/sidecar/internal/analyzer/schema_exclusion_test.go
@@ -1,0 +1,38 @@
+package analyzer
+
+import "testing"
+
+func TestIsSystemSchema(t *testing.T) {
+	sys := []string{"pg_catalog", "pg_toast", "information_schema", "_timescaledb_catalog", "_timescaledb_internal", "google_ml", "PG_CATALOG"}
+	for _, s := range sys {
+		if !isSystemSchema(s) {
+			t.Errorf("isSystemSchema(%q) = false, want true", s)
+		}
+	}
+	user := []string{"public", "app", "lifeos", "sales", "timescaledb_information"}
+	for _, s := range user {
+		if isSystemSchema(s) {
+			t.Errorf("isSystemSchema(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestIsSubset_IncludeColumns(t *testing.T) {
+	// a=(memo_id) INCLUDE (payload), b=(memo_id, claim_type): b does NOT
+	// serve a's INCLUDE column -> a is NOT a droppable subset.
+	a := ParsedIndex{Schema: "public", Table: "t", Columns: []string{"memo_id"}, IncludeCols: []string{"payload"}}
+	b := ParsedIndex{Schema: "public", Table: "t", Columns: []string{"memo_id", "claim_type"}}
+	if IsSubset(a, b) {
+		t.Error("subset with uncovered INCLUDE column must not be a subset")
+	}
+	// b now includes payload -> a IS covered.
+	b2 := ParsedIndex{Schema: "public", Table: "t", Columns: []string{"memo_id", "claim_type"}, IncludeCols: []string{"payload"}}
+	if !IsSubset(a, b2) {
+		t.Error("subset whose INCLUDE is covered should be a subset")
+	}
+	// plain leading-prefix subset (no INCLUDE) still works.
+	a2 := ParsedIndex{Schema: "public", Table: "t", Columns: []string{"memo_id"}}
+	if !IsSubset(a2, b) {
+		t.Error("plain leading-prefix subset should be a subset")
+	}
+}


### PR DESCRIPTION
Audit of why autonomous mode was unsafe surfaced three recommendation-quality bugs:

- **Connection advisor** sized `max_connections` against *active* connections, producing dangerous values (`max_connections=20` on a DB with 28 open connections). Now sizes against **total/open** backends with a hard deterministic floor (`filterUnsafeMaxConnections`).
- **Index rules** analyzed system/extension-internal schemas, recommending drops of `_timescaledb_catalog` indexes. Now skipped via `isSystemSchema`.
- **Subset-index** detection ignored INCLUDE columns. Now requires the superset to serve them, so index-only-scan indexes aren't flagged redundant.

Existing bad findings on the live fleet were suppressed. Note: this branch also carries the `execution_mode: auto` change to the local monitor config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)