### PR TITLE
fix(analyzer): drop a subset index only when the superset is a close replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@
   - Subset-index detection now also requires the superset to serve the subset's
     `INCLUDE` columns, so an index supporting an index-only scan isn't flagged
     as redundant.
+  - Subset-index detection now only recommends dropping a narrow index when the
+    superset is a *close* replacement — at most ~2 extra key columns, not more
+    than ~3x the on-disk size, and not a heavily-used narrow index — so a `(c1)`
+    index is no longer replaced by a wide `(c1..c12)` one.
 
 ## v1.1 (2026-05-10) -- AgentDB Cloud Provisioning Release
 

--- a/sidecar/internal/analyzer/rules_index.go
+++ b/sidecar/internal/analyzer/rules_index.go
@@ -261,6 +261,9 @@ func ruleDuplicateIndexes(
 				if isConstraintBacked(a.info) {
 					continue
 				}
+				if !subsetWorthDropping(a.parsed, b.parsed, a.info, b.info) {
+					continue
+				}
 				if seen[aIdent] {
 					continue
 				}
@@ -270,6 +273,9 @@ func ruleDuplicateIndexes(
 				))
 			} else if IsSubset(b.parsed, a.parsed) {
 				if isConstraintBacked(b.info) {
+					continue
+				}
+				if !subsetWorthDropping(b.parsed, a.parsed, b.info, a.info) {
 					continue
 				}
 				if seen[bIdent] {
@@ -307,6 +313,44 @@ func chooseDuplicateDrop(
 
 func isConstraintBacked(idx collector.IndexStats) bool {
 	return idx.IsPrimary || idx.IsUnique
+}
+
+const (
+	// A wide/large superset is a poor replacement for a narrow index:
+	// serving a `WHERE c1 = ?` lookup from a fat composite reads much wider
+	// tuples (more I/O per probe) than the dedicated narrow index, so the
+	// narrow index earns its keep as a faster access path. Only recommend
+	// dropping the subset when the superset is a *close* replacement.
+	maxSubsetExtraKeyCols = 2   // superset may add at most this many key cols
+	maxSubsetSizeRatio    = 3.0 // superset may be at most this many x the size
+	// A heavily-used narrow index is actively serving lookups; even a
+	// modestly wider superset would slow them all down, so keep it.
+	subsetHeavyUseScans = 100_000
+)
+
+// subsetWorthDropping reports whether dropping the narrow `sub` index in
+// favor of the wider `sup` is a net win. Column count is the operator's
+// intuition ("don't replace (c1) with (c1..c12)"); index byte size is the
+// more accurate signal because it accounts for actual column widths, and
+// usage tells us whether the narrow index is even earning its keep.
+func subsetWorthDropping(
+	sub, sup ParsedIndex, subInfo, supInfo collector.IndexStats,
+) bool {
+	if len(sup.Columns)-len(sub.Columns) > maxSubsetExtraKeyCols {
+		return false
+	}
+	if subInfo.IndexBytes > 0 && supInfo.IndexBytes > 0 &&
+		float64(supInfo.IndexBytes) >
+			float64(subInfo.IndexBytes)*maxSubsetSizeRatio {
+		return false
+	}
+	// A heavily-used narrow index is worth keeping unless the superset is
+	// nearly the same width (≤1 extra key column).
+	if subInfo.IdxScan >= subsetHeavyUseScans &&
+		len(sup.Columns)-len(sub.Columns) > 1 {
+		return false
+	}
+	return true
 }
 
 func subsetFinding(

--- a/sidecar/internal/analyzer/subset_worth_test.go
+++ b/sidecar/internal/analyzer/subset_worth_test.go
@@ -1,0 +1,36 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/pg-sage/sidecar/internal/collector"
+)
+
+func TestSubsetWorthDropping(t *testing.T) {
+	sub := ParsedIndex{Columns: []string{"c1"}}
+	// (c1) covered by (c1,c2) — 1 extra col, similar size -> worth dropping.
+	if !subsetWorthDropping(sub, ParsedIndex{Columns: []string{"c1", "c2"}},
+		collector.IndexStats{IndexBytes: 1000}, collector.IndexStats{IndexBytes: 1500}) {
+		t.Error("close superset (1 extra col, 1.5x size) should be droppable")
+	}
+	// (c1) covered by (c1..c12) — 11 extra cols -> NOT worth dropping.
+	wide := ParsedIndex{Columns: []string{"c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12"}}
+	if subsetWorthDropping(sub, wide, collector.IndexStats{IndexBytes: 1000}, collector.IndexStats{IndexBytes: 12000}) {
+		t.Error("(c1) should NOT be replaced by (c1..c12)")
+	}
+	// 2 extra cols but superset is 5x the size -> size guard rejects.
+	if subsetWorthDropping(sub, ParsedIndex{Columns: []string{"c1", "c2", "c3"}},
+		collector.IndexStats{IndexBytes: 1000}, collector.IndexStats{IndexBytes: 5000}) {
+		t.Error("5x-larger superset should be rejected by size guard")
+	}
+	// heavily-used narrow index, 2 extra cols -> keep it.
+	if subsetWorthDropping(sub, ParsedIndex{Columns: []string{"c1", "c2", "c3"}},
+		collector.IndexStats{IndexBytes: 1000, IdxScan: 500_000}, collector.IndexStats{IndexBytes: 2000}) {
+		t.Error("heavily-used narrow index with >1 extra col should be kept")
+	}
+	// heavily-used but superset only 1 extra col + similar size -> still droppable.
+	if !subsetWorthDropping(sub, ParsedIndex{Columns: []string{"c1", "c2"}},
+		collector.IndexStats{IndexBytes: 1000, IdxScan: 500_000}, collector.IndexStats{IndexBytes: 1300}) {
+		t.Error("near-identical superset should be droppable even if heavily used")
+	}
+}


### PR DESCRIPTION
A leading-prefix subset index is redundant in the *planner* sense but not the *performance* sense — serving `WHERE c1 = ?` from a fat `(c1..c12)` composite reads far wider tuples than a dedicated `(c1)` index. `subsetWorthDropping` now gates on column count (≤2 extra keys — the operator's intuition), index byte size (≤~3x — the accurate width signal), and usage (keep a heavily-scanned narrow index). Stops "replace (c1) with (c1..c12)" while still flagging near-identical redundant indexes.