### PR TITLE
chore(local-monitor): ignore runtime logs/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /regression.diffs
 /regression.out
 /log/
+/logs/
 /tmp_check/
 sidecar/sage-sidecar
 sidecar/sage-sidecar-standalone.exe


### PR DESCRIPTION
One-line hygiene from the LifeOS dogfood-join session (v3-D1).

The detached local-monitor launcher now redirects sidecar output to `logs/local_monitor.{out,err}.log` so the next silent death (the 14:44 instance today died with no trace) is diagnosable. Keep that directory untracked, alongside the existing `/log/`.

Config-only repo change; no code touched, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)