### PR TITLE
feat: couple autonomy toggle to the gate + friendly maintenance windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ __pycache__/
 *.pyc
 DECISIONS.md
 REENTRY.md
+logs/
+*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,17 @@
   marker and any `sage.`-schema query from analysis.
 - `isThinkingModel` now covers the `gemini-3.x` series (reserves output-token
   budget for thinking models, e.g. `gemini-3.5-flash`).
+- **Autonomy gate coupling:** raising the trust level to advisory/autonomous
+  now opens the execution gate. A `manual` execution_mode combined with a
+  non-observation trust level was a silent contradiction (the "turned on
+  autonomous, nothing happened" trap); the executor now treats that as `auto`
+  (still gated by trust tier, ramp age, and the maintenance window). Works live
+  and across restart, since trust level persists in `sage.config`.
+- **Maintenance windows are no longer cron-only.** The window accepts friendly
+  forms: presets (`nights`, `weeknights`, `weekends`, `off-hours`,
+  `business-hours`, `always`, `never`) and day-qualified ranges
+  (`weekdays 01:00-05:00`, `Sat-Sun 02:00-06:00`, `Mon,Wed,Fri 22:00-04:00`),
+  alongside the existing `HH:MM-HH:MM` and cron syntax.
 
 ### Fixed
 

--- a/local_monitor_config.yaml
+++ b/local_monitor_config.yaml
@@ -6,7 +6,7 @@ mode: fleet
 defaults:
   max_connections: 2
   trust_level: observation
-  execution_mode: auto
+  execution_mode: manual
   collector_interval_seconds: 30
   analyzer_interval_seconds: 60
 

--- a/sidecar/internal/executor/coverage_boost_test.go
+++ b/sidecar/internal/executor/coverage_boost_test.go
@@ -272,9 +272,13 @@ func TestCoverage_InMaintenanceWindow_WithLeadingWhitespace(t *testing.T) {
 // TestCoverage_RunCycle_ManualMode verifies that manual mode returns
 // immediately without touching the pool.
 func TestCoverage_RunCycle_ManualMode(t *testing.T) {
+	// Manual mode + observation trust skips the cycle early (before the
+	// nil pool is touched). Note: under a non-observation trust level the
+	// gate promotes manual to auto (effectiveExecMode), so the early
+	// return specifically requires observation trust here.
 	e := &Executor{
 		cfg: &config.Config{
-			Trust: config.TrustConfig{Level: "autonomous"},
+			Trust: config.TrustConfig{Level: "observation"},
 		},
 		recentActions: make(map[string]time.Time),
 		logFn:         func(string, string, ...any) {},
@@ -282,7 +286,7 @@ func TestCoverage_RunCycle_ManualMode(t *testing.T) {
 		pool:          nil, // would panic if accessed
 	}
 
-	// Should not panic.
+	// Should not panic — manual + observation returns before any pool use.
 	e.RunCycle(context.Background(), false)
 }
 

--- a/sidecar/internal/executor/effective_execmode_test.go
+++ b/sidecar/internal/executor/effective_execmode_test.go
@@ -1,0 +1,37 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/pg-sage/sidecar/internal/config"
+)
+
+func TestEffectiveExecMode(t *testing.T) {
+	mk := func(execMode, trustOverride, cfgTrust string) *Executor {
+		return &Executor{
+			execMode:           execMode,
+			trustLevelOverride: trustOverride,
+			cfg:                &config.Config{Trust: config.TrustConfig{Level: cfgTrust}},
+		}
+	}
+	cases := []struct {
+		name                        string
+		execMode, override, cfgTrust string
+		want                        string
+	}{
+		{"manual+observation stays manual", "manual", "", "observation", "manual"},
+		{"manual+advisory -> auto", "manual", "", "advisory", "auto"},
+		{"manual+autonomous -> auto", "manual", "", "autonomous", "auto"},
+		{"manual+autonomous via override -> auto", "manual", "autonomous", "observation", "auto"},
+		{"manual+empty trust stays manual", "manual", "", "", "manual"},
+		{"auto always auto", "auto", "", "observation", "auto"},
+		{"approval is respected (not promoted)", "approval", "", "autonomous", "approval"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := mk(c.execMode, c.override, c.cfgTrust).effectiveExecMode(); got != c.want {
+				t.Errorf("effectiveExecMode() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/sidecar/internal/executor/executor.go
+++ b/sidecar/internal/executor/executor.go
@@ -204,6 +204,22 @@ func (e *Executor) ExecutionMode() string {
 	return e.execMode
 }
 
+// effectiveExecMode resolves the execution mode the gate should use.
+// "manual" combined with a non-observation trust level is contradictory:
+// the operator raised trust to act autonomously, but a manual gate would
+// silently block everything (the "I turned on autonomous and nothing
+// happened" trap). Honor the trust intent and treat it as "auto" — actions
+// are still gated by trust tier, ramp age, and the maintenance window.
+// "auto" and the explicit "approval" choice are returned unchanged.
+func (e *Executor) effectiveExecMode() string {
+	if e.execMode == "manual" {
+		if lvl := e.TrustLevel(); lvl != "" && lvl != "observation" {
+			return "auto"
+		}
+	}
+	return e.execMode
+}
+
 // shouldExecute checks whether a finding should be executed,
 // respecting any per-instance trust level override.
 func (e *Executor) shouldExecute(
@@ -222,8 +238,10 @@ func (e *Executor) shouldExecute(
 // RunCycle is called after each analyzer cycle to evaluate and execute
 // any actionable findings.
 func (e *Executor) RunCycle(ctx context.Context, isReplica bool) {
-	// Manual mode: no auto-proposals or executions.
-	if e.execMode == "manual" {
+	// Manual mode blocks all execution — but a non-observation trust level
+	// promotes manual to auto (see effectiveExecMode), so raising trust in
+	// the UI actually opens the gate without a separate execution_mode flip.
+	if e.effectiveExecMode() == "manual" {
 		return
 	}
 

--- a/sidecar/internal/executor/maintenance_window_test.go
+++ b/sidecar/internal/executor/maintenance_window_test.go
@@ -1,0 +1,57 @@
+package executor
+
+import (
+	"testing"
+	"time"
+)
+
+func TestInMaintenanceWindow_FriendlyForms(t *testing.T) {
+	// Known weekdays: 2024-01-01 Mon, 01-03 Wed, 01-06 Sat.
+	mk := func(y, m, d, hh, mm int) time.Time {
+		return time.Date(y, time.Month(m), d, hh, mm, 0, 0, time.UTC)
+	}
+	monNight := mk(2024, 1, 1, 2, 0)   // Mon 02:00
+	monNoon := mk(2024, 1, 1, 12, 0)   // Mon 12:00
+	wedNight := mk(2024, 1, 3, 2, 0)   // Wed 02:00
+	wedAM := mk(2024, 1, 3, 10, 0)     // Wed 10:00
+	wedEve := mk(2024, 1, 3, 20, 0)    // Wed 20:00
+	satNight := mk(2024, 1, 6, 3, 0)   // Sat 03:00
+	satNoon := mk(2024, 1, 6, 14, 0)   // Sat 14:00
+
+	cases := []struct {
+		expr string
+		now  time.Time
+		want bool
+	}{
+		{"", monNight, false},
+		{"always", monNoon, true},
+		{"never", monNight, false},
+		{"off", monNight, false},
+		{"nights", monNight, true},      // 22:00-06:00
+		{"nights", monNoon, false},
+		{"weeknights", wedNight, true},  // weekdays 22:00-06:00
+		{"weeknights", satNight, false}, // Sat is not a weeknight
+		{"weekends", satNoon, true},     // all day Sat
+		{"weekends", monNoon, false},
+		{"weekdays", wedAM, true},
+		{"weekdays", satNoon, false},
+		{"business-hours", wedAM, true}, // weekdays 09:00-17:00
+		{"business-hours", wedEve, false},
+		{"business-hours", satNoon, false},
+		{"weekdays 01:00-05:00", wedNight, true},
+		{"weekdays 01:00-05:00", wedAM, false},
+		{"weekdays 01:00-05:00", satNight, false}, // not a weekday
+		{"Sat-Sun 02:00-06:00", satNight, true},
+		{"Sat-Sun 02:00-06:00", wedNight, false},
+		{"Mon,Wed,Fri 22:00-04:00", wedNight, true}, // Wed 02:00 in 22-04 wrap
+		{"Mon,Wed,Fri 22:00-04:00", satNight, false},
+		{"02:00-06:00", satNight, true},  // plain daily range still works
+		{"0 2 * * *", mk(2024, 1, 1, 2, 30), true}, // cron still works
+	}
+	for _, c := range cases {
+		if got := inMaintenanceWindowAt(c.expr, c.now); got != c.want {
+			t.Errorf("inMaintenanceWindowAt(%q, %s) = %v, want %v",
+				c.expr, c.now.Format("Mon 15:04"), got, c.want)
+		}
+	}
+}

--- a/sidecar/internal/executor/mode_test.go
+++ b/sidecar/internal/executor/mode_test.go
@@ -138,11 +138,13 @@ func TestSetExecutionMode(t *testing.T) {
 }
 
 func TestManualMode_SkipsRunCycle(t *testing.T) {
-	// Manual mode should return immediately without checking
-	// emergency stop or processing any findings.
+	// Manual mode + observation trust returns immediately without checking
+	// emergency stop or processing any findings. (Under a non-observation
+	// trust level the gate promotes manual to auto via effectiveExecMode,
+	// so this case specifically uses observation trust.)
 	e := &Executor{
 		cfg: &config.Config{
-			Trust: config.TrustConfig{Level: "autonomous"},
+			Trust: config.TrustConfig{Level: "observation"},
 		},
 		recentActions: make(map[string]time.Time),
 		logFn:         func(string, string, ...any) {},
@@ -151,8 +153,21 @@ func TestManualMode_SkipsRunCycle(t *testing.T) {
 		pool: nil,
 	}
 
-	// Should not panic — manual mode returns early.
+	// Should not panic — manual + observation returns early.
 	e.RunCycle(context.Background(), false)
+}
+
+// TestManualMode_AutonomousTrustOpensGate verifies the coupling: manual
+// execution_mode combined with a non-observation trust level is promoted
+// to auto, so RunCycle no longer short-circuits at the manual gate.
+func TestManualMode_AutonomousTrustOpensGate(t *testing.T) {
+	e := &Executor{
+		cfg:      &config.Config{Trust: config.TrustConfig{Level: "autonomous"}},
+		execMode: "manual",
+	}
+	if got := e.effectiveExecMode(); got != "auto" {
+		t.Errorf("manual + autonomous trust = %q, want auto (gate should open)", got)
+	}
 }
 
 func TestNilActionStore_AutoModeBehavior(t *testing.T) {

--- a/sidecar/internal/executor/trust.go
+++ b/sidecar/internal/executor/trust.go
@@ -73,21 +73,36 @@ func inMaintenanceWindow(cronExpr string) bool {
 }
 
 func inMaintenanceWindowAt(cronExpr string, now time.Time) bool {
-	if cronExpr == "" {
+	s := strings.TrimSpace(cronExpr)
+	if s == "" {
 		return false
 	}
 
-	trimmed := strings.TrimSpace(cronExpr)
-	if strings.EqualFold(trimmed, "always") {
+	// Friendly preset names (nights, weekends, off-hours, business-hours,
+	// ...) expand to a canonical form so users who have never touched cron
+	// can express a maintenance window.
+	if canon, ok := maintenancePresets[strings.ToLower(s)]; ok {
+		s = canon
+	}
+	switch strings.ToLower(s) {
+	case "never", "off", "none", "disabled":
+		return false
+	case "always", "anytime", "24x7", "24/7":
 		return true
 	}
 
 	// "HH:MM-HH:MM" daily time range.
-	if r, ok := parseTimeRange(trimmed); ok {
+	if r, ok := parseTimeRange(s); ok {
 		return r.contains(now)
 	}
 
-	parts := strings.Fields(trimmed)
+	// Friendly "<days> [HH:MM-HH:MM]" — e.g. "weekdays 01:00-05:00",
+	// "weekends", "Sat-Sun 02:00-06:00", "Mon,Wed,Fri 22:00-04:00".
+	if in, ok := parseFriendlyWindowAt(s, now); ok {
+		return in
+	}
+
+	parts := strings.Fields(s)
 	if len(parts) < 2 {
 		return false
 	}
@@ -140,6 +155,112 @@ func inMaintenanceWindowAt(cronExpr string, now time.Time) bool {
 	windowEnd := windowStart.Add(1 * time.Hour)
 
 	return !now.Before(windowStart) && now.Before(windowEnd)
+}
+
+// maintenancePresets map friendly names to a canonical maintenance-window
+// expression so a non-cron user can pick a sensible window by name.
+var maintenancePresets = map[string]string{
+	"nights":         "daily 22:00-06:00",
+	"nightly":        "daily 22:00-06:00",
+	"overnight":      "daily 22:00-06:00",
+	"weeknights":     "weekdays 22:00-06:00",
+	"off-hours":      "daily 20:00-08:00",
+	"off-peak":       "daily 20:00-08:00",
+	"business-hours": "weekdays 09:00-17:00",
+	"weekends":       "weekends",
+	"weekend":        "weekends",
+	"weekdays":       "weekdays",
+	"weekday":        "weekdays",
+}
+
+// parseFriendlyWindowAt handles "<days> [HH:MM-HH:MM]" expressions, where
+// days is a name (weekdays, weekends, daily), a list (Sat,Sun), or a range
+// (Mon-Fri). matched=false means the string is not this form, so the
+// caller falls through to cron parsing.
+func parseFriendlyWindowAt(s string, now time.Time) (inWindow, matched bool) {
+	fields := strings.Fields(s)
+	if len(fields) == 0 || len(fields) > 2 {
+		return false, false
+	}
+	dayMatch, ok := matchesDaySpec(fields[0], now.Weekday())
+	if !ok {
+		return false, false
+	}
+	if len(fields) == 1 {
+		return dayMatch, true // all day on those days
+	}
+	r, ok := parseTimeRange(fields[1])
+	if !ok {
+		return false, false
+	}
+	return dayMatch && r.contains(now), true
+}
+
+// matchesDaySpec reports whether weekday wd is covered by a day spec like
+// "daily", "weekdays", "weekends", "mon-fri", "sat,sun", or "mon,wed,fri".
+// ok=false means the token is not a recognized day spec.
+func matchesDaySpec(spec string, wd time.Weekday) (match, ok bool) {
+	switch strings.ToLower(strings.TrimSpace(spec)) {
+	case "daily", "everyday", "every-day", "all", "all-days":
+		return true, true
+	case "weekday", "weekdays":
+		return wd >= time.Monday && wd <= time.Friday, true
+	case "weekend", "weekends":
+		return wd == time.Saturday || wd == time.Sunday, true
+	}
+	var set [7]bool
+	any := false
+	for _, part := range strings.Split(spec, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if dash := strings.IndexByte(part, '-'); dash > 0 {
+			a, oka := dayNum(part[:dash])
+			b, okb := dayNum(part[dash+1:])
+			if !oka || !okb {
+				return false, false
+			}
+			for d := a; ; d = (d + 1) % 7 { // inclusive, wraps (fri-mon)
+				set[d] = true
+				if d == b {
+					break
+				}
+			}
+			any = true
+		} else {
+			d, okd := dayNum(part)
+			if !okd {
+				return false, false
+			}
+			set[d] = true
+			any = true
+		}
+	}
+	if !any {
+		return false, false
+	}
+	return set[int(wd)], true
+}
+
+func dayNum(s string) (int, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "sun", "sunday":
+		return 0, true
+	case "mon", "monday":
+		return 1, true
+	case "tue", "tues", "tuesday":
+		return 2, true
+	case "wed", "weds", "wednesday":
+		return 3, true
+	case "thu", "thur", "thurs", "thursday":
+		return 4, true
+	case "fri", "friday":
+		return 5, true
+	case "sat", "saturday":
+		return 6, true
+	}
+	return 0, false
 }
 
 // timeRange is a daily window expressed in minutes since midnight.


### PR DESCRIPTION
Two UX fixes so autonomous mode is actually usable:

- **Autonomy gate coupling** — `manual` execution_mode + non-observation trust was a silent contradiction (the "turned on autonomous, nothing happened" trap). The executor now promotes it to `auto` (`effectiveExecMode`), so raising trust in the UI opens the gate — live and across restart (trust persists in `sage.config`). Still gated by trust tier, ramp, and maintenance window.
- **Friendly maintenance windows** — accepts presets (`nights`, `weekends`, `off-hours`, `business-hours`, …) and day-qualified ranges (`weekdays 01:00-05:00`, `Sat-Sun 02:00-06:00`) in addition to `HH:MM-HH:MM` and cron.

Two manual-mode tests encoded the old "manual always skips" contract; updated to `observation` trust (still skips) + added coverage for the new promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)