### PR TITLE
feat: cloud-aware config apply + reload so ALTER SYSTEM takes effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,16 @@
 
 ### Fixed
 
+- **Config changes now take effect (and are cloud-aware).** Previously an
+  `ALTER SYSTEM` action wrote `postgresql.auto.conf` but never reloaded, so the
+  change silently never applied. The executor now: reloads (`pg_reload_conf`)
+  after a reload-only GUC on a self-managed server so it takes effect; marks a
+  restart-only GUC (`shared_buffers`, `max_connections`, …) as
+  `applied_pending_restart`; and on a **managed provider** (RDS/Aurora,
+  Cloud SQL/AlloyDB, Azure) skips `ALTER SYSTEM` entirely (it's blocked there)
+  and records that the change must be applied via the provider's parameter
+  group / database flags. The action log outcome now reflects whether a config
+  change is actually in effect.
 - **Retention:** `cleanStaleFirstSeen` no longer skips stale-key cleanup when
   the index snapshot is empty (a regression from an over-broad safety guard).
 - **Cases:** pg_sage no longer surfaces its own monitoring queries as Cases.

--- a/sidecar/internal/executor/config_apply.go
+++ b/sidecar/internal/executor/config_apply.go
@@ -1,0 +1,134 @@
+package executor
+
+import (
+	"context"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// restartRequiredParams are GUCs whose change only takes effect after a
+// PostgreSQL restart — pg_sage cannot restart the server, so an
+// ALTER SYSTEM for these is written to postgresql.auto.conf but does not
+// apply until the operator restarts.
+var restartRequiredParams = map[string]bool{
+	"shared_buffers":           true,
+	"max_connections":          true,
+	"wal_buffers":              true,
+	"max_worker_processes":     true,
+	"max_prepared_transactions": true,
+	"max_wal_senders":          true,
+	"max_replication_slots":    true,
+	"huge_pages":               true,
+	"shared_preload_libraries": true,
+	"max_locks_per_transaction": true,
+	"superuser_reserved_connections": true,
+}
+
+// managedProviders are platforms where ALTER SYSTEM is disallowed; config
+// changes must go through the provider's parameter group / database flags
+// (and the provider reloads automatically), not ALTER SYSTEM.
+var managedProviders = map[string]bool{
+	"rds": true, "aurora": true, "aws": true,
+	"cloud-sql": true, "cloudsql": true, "gcp": true,
+	"alloydb": true,
+	"azure": true, "azure-flexible": true, "azure-single": true,
+}
+
+// outcomeStatus maps whether a config change is live to an action_log
+// outcome: "success" when in effect, "applied_pending_restart" when the
+// value was written but a restart is still required to apply it.
+func outcomeStatus(inEffect bool) string {
+	if inEffect {
+		return "success"
+	}
+	return "applied_pending_restart"
+}
+
+// isManagedProvider reports whether the cloud environment is a managed
+// PostgreSQL service where ALTER SYSTEM is blocked.
+func isManagedProvider(env string) bool {
+	return managedProviders[strings.ToLower(strings.TrimSpace(env))]
+}
+
+// isAlterSystem reports whether sql is an ALTER SYSTEM SET/RESET statement.
+func isAlterSystem(sql string) bool {
+	return strings.HasPrefix(
+		strings.ToUpper(strings.TrimSpace(sql)), "ALTER SYSTEM")
+}
+
+// configParamFromSQL extracts the first GUC name from an
+// "ALTER SYSTEM SET/RESET <param> ..." statement. Returns "" if not found.
+func configParamFromSQL(sql string) string {
+	upper := strings.ToUpper(sql)
+	var rest string
+	switch {
+	case strings.Contains(upper, "ALTER SYSTEM SET "):
+		i := strings.Index(upper, "ALTER SYSTEM SET ")
+		rest = sql[i+len("ALTER SYSTEM SET "):]
+	case strings.Contains(upper, "ALTER SYSTEM RESET "):
+		i := strings.Index(upper, "ALTER SYSTEM RESET ")
+		rest = sql[i+len("ALTER SYSTEM RESET "):]
+	default:
+		return ""
+	}
+	rest = strings.TrimSpace(rest)
+	// param ends at the first space, '=', or ';'
+	end := strings.IndexAny(rest, " =;")
+	if end >= 0 {
+		rest = rest[:end]
+	}
+	return strings.Trim(strings.TrimSpace(rest), `"'`)
+}
+
+// configApplyOutcome describes how a config change should be applied and
+// whether it is actually in effect after the ALTER SYSTEM ran.
+type configApplyOutcome struct {
+	InEffect bool   // true once the change is live
+	Note     string // human-readable status for the action log
+}
+
+// applyConfigChange finalizes an ALTER SYSTEM config change so its effect
+// (or lack of it) is accurate. On a self-managed server it reloads the
+// configuration for reload-only GUCs; restart-only GUCs are written but
+// flagged as needing a restart. Managed providers are flagged because the
+// change should have gone through their parameter group instead.
+func applyConfigChange(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	sql, cloudEnv string,
+	logFn func(string, string, ...any),
+) configApplyOutcome {
+	param := configParamFromSQL(sql)
+
+	if isManagedProvider(cloudEnv) {
+		return configApplyOutcome{
+			InEffect: false,
+			Note: "managed provider (" + cloudEnv + "): apply " + param +
+				" via the provider parameter group / database flags — " +
+				"ALTER SYSTEM does not take effect here",
+		}
+	}
+	if restartRequiredParams[strings.ToLower(param)] {
+		return configApplyOutcome{
+			InEffect: false,
+			Note: param + " written to postgresql.auto.conf; " +
+				"requires a PostgreSQL restart to take effect",
+		}
+	}
+	// Self-managed, reload-only parameter: reload so it takes effect now.
+	if _, err := pool.Exec(ctx,
+		"/* pg_sage */ SELECT pg_reload_conf()"); err != nil {
+		if logFn != nil {
+			logFn("executor", "pg_reload_conf after %s failed: %v", param, err)
+		}
+		return configApplyOutcome{
+			InEffect: false,
+			Note:     param + " set; pg_reload_conf failed: " + err.Error(),
+		}
+	}
+	return configApplyOutcome{
+		InEffect: true,
+		Note:     param + " applied and reloaded (in effect)",
+	}
+}

--- a/sidecar/internal/executor/config_apply_test.go
+++ b/sidecar/internal/executor/config_apply_test.go
@@ -1,0 +1,50 @@
+package executor
+
+import "testing"
+
+func TestConfigParamFromSQL(t *testing.T) {
+	cases := map[string]string{
+		"ALTER SYSTEM SET work_mem = '16MB';":            "work_mem",
+		"ALTER SYSTEM SET max_connections = 100":         "max_connections",
+		"alter system set random_page_cost = 1.1;":       "random_page_cost",
+		"ALTER SYSTEM RESET shared_buffers;":             "shared_buffers",
+		"CREATE INDEX ON t (a);":                         "",
+	}
+	for sql, want := range cases {
+		if got := configParamFromSQL(sql); got != want {
+			t.Errorf("configParamFromSQL(%q) = %q, want %q", sql, got, want)
+		}
+	}
+}
+
+func TestIsManagedProvider(t *testing.T) {
+	managed := []string{"rds", "aurora", "cloud-sql", "cloudsql", "alloydb", "azure", "AWS"}
+	for _, p := range managed {
+		if !isManagedProvider(p) {
+			t.Errorf("isManagedProvider(%q) = false, want true", p)
+		}
+	}
+	for _, p := range []string{"self-managed", "postgres", "", "ec2"} {
+		if isManagedProvider(p) {
+			t.Errorf("isManagedProvider(%q) = true, want false", p)
+		}
+	}
+}
+
+func TestRestartRequiredClassification(t *testing.T) {
+	if !restartRequiredParams["shared_buffers"] || !restartRequiredParams["max_connections"] {
+		t.Error("shared_buffers/max_connections must be restart-required")
+	}
+	if restartRequiredParams["work_mem"] || restartRequiredParams["random_page_cost"] {
+		t.Error("work_mem/random_page_cost are reload-only, not restart-required")
+	}
+}
+
+func TestOutcomeStatus(t *testing.T) {
+	if outcomeStatus(true) != "success" {
+		t.Error("in-effect should be success")
+	}
+	if outcomeStatus(false) != "applied_pending_restart" {
+		t.Error("not-in-effect should be applied_pending_restart")
+	}
+}

--- a/sidecar/internal/executor/executor.go
+++ b/sidecar/internal/executor/executor.go
@@ -467,6 +467,22 @@ func (e *Executor) executeFinding(
 ) {
 	beforeState := e.snapshotBeforeState(ctx, targetQueryIDs(f))
 
+	// Config changes on managed providers must go through the provider's
+	// parameter group / database flags, not ALTER SYSTEM (which is blocked
+	// there). Don't attempt it — record why so the operator applies it via
+	// the cloud console instead of seeing a generic failure.
+	if isAlterSystem(f.RecommendedSQL) &&
+		isManagedProvider(e.cfg.CloudEnvironment) {
+		param := configParamFromSQL(f.RecommendedSQL)
+		e.logFn("executor",
+			"%s: %s must be set via the parameter group, not ALTER SYSTEM",
+			e.cfg.CloudEnvironment, param)
+		e.logAction(ctx, f, findingID, beforeState,
+			fmt.Errorf("managed provider %s: apply %s via parameter "+
+				"group/flags", e.cfg.CloudEnvironment, param))
+		return
+	}
+
 	ddlTimeout := e.cfg.Safety.DDLTimeout()
 	lockOpt := WithLockTimeout(e.cfg.Safety.LockTimeout())
 	var execErr error
@@ -512,6 +528,17 @@ func (e *Executor) executeFinding(
 		notify.ActionExecutedEvent(
 			f.Title, f.RecommendedSQL, e.databaseName))
 	e.recentActions[f.ObjectIdentifier] = time.Now()
+
+	// Config changes: reload so a reload-only GUC takes effect now, or
+	// record that a restart is still required. Without this, ALTER SYSTEM
+	// only writes postgresql.auto.conf and the change never applies.
+	if isAlterSystem(f.RecommendedSQL) {
+		outcome := applyConfigChange(
+			ctx, e.pool, f.RecommendedSQL, e.cfg.CloudEnvironment, e.logFn)
+		e.logFn("executor", "config: %s", outcome.Note)
+		updateActionOutcome(ctx, e.pool, actionID,
+			outcomeStatus(outcome.InEffect), outcome.Note)
+	}
 
 	// Write a plain-English audit justification (C4). Async so the LLM
 	// latency never blocks the cycle; WithoutCancel so it survives the


### PR DESCRIPTION
`ALTER SYSTEM` actions wrote `postgresql.auto.conf` but never reloaded, so config changes silently never applied. The executor now finalizes them by parameter + platform:

- **self-managed, reload-only** (`work_mem`, …) → `pg_reload_conf()` → in effect.
- **self-managed, restart-only** (`shared_buffers`, `max_connections`, …) → `applied_pending_restart`.
- **managed provider** (RDS/Aurora, Cloud SQL/AlloyDB, Azure) → `ALTER SYSTEM` is blocked, so skip it and record that the change must go via the provider parameter group / flags — no false success or misleading failure.

The action_log outcome/reason now reflect whether the change is actually in effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)