### PR TITLE
fix: subset drops advisory + split multi-statement config + resume after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,19 @@
 
 ### Fixed
 
+- **Subset-index drops are advisory now.** A leading-prefix "subset" index
+  (`(c1)` covered by `(c1, c2)`) is no longer auto-dropped — it's a judgment
+  call (read-perf trade-off, and apps that re-create their own indexes turn an
+  auto-drop into churn). It's surfaced as info/advisory; exact-duplicate index
+  drops remain automatic.
+- **Multi-statement config recommendations are split.** An advisor
+  recommendation carrying several `ALTER SYSTEM` statements (e.g. WAL tuning) is
+  split into one atomic, individually-validated action per parameter, instead
+  of being rejected by the executor as multi-statement SQL.
+- **Resume now works after a restart.** Resuming reconciled only the in-memory
+  state, so after a restart (in-memory "running", persisted flag "stopped")
+  resume couldn't clear the persisted `emergency_stop`. It now always
+  reconciles the persisted flag.
 - **Anti-oscillation guard.** If pg_sage applies the same successful action
   to an object repeatedly (e.g. dropping an index an app keeps re-creating),
   it now backs off after a few cycles and marks the finding acted-on, instead

--- a/sidecar/internal/advisor/prompt.go
+++ b/sidecar/internal/advisor/prompt.go
@@ -61,32 +61,62 @@ func parseLLMFindings(
 		rationale, _ := rec["rationale"].(string)
 		recSQL, _ := rec["recommended_sql"].(string)
 
-		// Doc-grounded validation (A3): drop any ALTER SYSTEM value the
-		// LLM proposed that falls outside the documented safe range.
-		if ok, reason := ValidateConfigSQL(recSQL); !ok {
-			if logFn != nil {
-				logFn("advisor", "rejecting recommendation: %s", reason)
-			}
-			continue
+		// A single recommendation may carry several config statements (e.g.
+		// WAL tuning sets checkpoint_timeout, max_wal_size, min_wal_size).
+		// Split them so each is an atomic, individually validated and
+		// reloadable action — the executor rejects multi-statement SQL. A
+		// single statement keeps its original shape (no behavior change).
+		stmts := splitSQLStatements(recSQL)
+		multi := len(stmts) > 1
+		if !multi {
+			stmts = []string{recSQL}
 		}
+		for _, stmt := range stmts {
+			// Doc-grounded validation (A3): drop any ALTER SYSTEM value the
+			// LLM proposed that falls outside the documented safe range.
+			if ok, reason := ValidateConfigSQL(stmt); !ok {
+				if logFn != nil {
+					logFn("advisor", "rejecting recommendation: %s", reason)
+				}
+				continue
+			}
 
-		risk := deriveActionRisk(recSQL)
+			oid := objID
+			title := fmt.Sprintf("%s recommendation for %s", category, objID)
+			if multi {
+				if param, _, ok := parseAlterSystemSet(stmt); ok {
+					oid = objID + ":" + param
+					title = fmt.Sprintf("%s: set %s", category, param)
+				}
+			}
 
-		findings = append(findings, analyzer.Finding{
-			Category:         category,
-			Severity:         severity,
-			ObjectType:       "configuration",
-			ObjectIdentifier: objID,
-			Title: fmt.Sprintf(
-				"%s recommendation for %s", category, objID,
-			),
-			Detail:         rec,
-			Recommendation: rationale,
-			RecommendedSQL: recSQL,
-			ActionRisk:     risk,
-		})
+			findings = append(findings, analyzer.Finding{
+				Category:         category,
+				Severity:         severity,
+				ObjectType:       "configuration",
+				ObjectIdentifier: oid,
+				Title:            title,
+				Detail:           rec,
+				Recommendation:   rationale,
+				RecommendedSQL:   stmt,
+				ActionRisk:       deriveActionRisk(stmt),
+			})
+		}
 	}
 	return findings
+}
+
+// splitSQLStatements splits a recommendation into individual statements,
+// preserving a single statement unchanged. Each returned statement ends
+// with a semicolon so it is a complete, single-statement action.
+func splitSQLStatements(sql string) []string {
+	var out []string
+	for _, s := range strings.Split(sql, ";") {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s+";")
+		}
+	}
+	return out
 }
 
 // deriveActionRisk returns the risk level for a recommended SQL

--- a/sidecar/internal/advisor/split_sql_test.go
+++ b/sidecar/internal/advisor/split_sql_test.go
@@ -1,0 +1,40 @@
+package advisor
+
+import "testing"
+
+func TestSplitSQLStatements(t *testing.T) {
+	multi := splitSQLStatements(
+		"ALTER SYSTEM SET checkpoint_timeout = '900s'; ALTER SYSTEM SET max_wal_size = '16GB'; ALTER SYSTEM SET min_wal_size = '4GB';")
+	if len(multi) != 3 {
+		t.Fatalf("expected 3 statements, got %d: %v", len(multi), multi)
+	}
+	for _, s := range multi {
+		if s[len(s)-1] != ';' {
+			t.Errorf("statement should end with ;: %q", s)
+		}
+	}
+	one := splitSQLStatements("ALTER SYSTEM SET work_mem = '16MB';")
+	if len(one) != 1 {
+		t.Errorf("single statement: got %d", len(one))
+	}
+	if len(splitSQLStatements("")) != 0 {
+		t.Error("empty SQL should yield 0 statements")
+	}
+}
+
+func TestParseLLMFindings_SplitsMultiStatement(t *testing.T) {
+	raw := `[{"object_identifier":"instance","severity":"warning","rationale":"tune WAL",` +
+		`"recommended_sql":"ALTER SYSTEM SET checkpoint_timeout = '900s'; ALTER SYSTEM SET max_wal_size = '16GB';"}]`
+	fs := parseLLMFindings(raw, "wal_tuning", func(string, string, ...any) {})
+	if len(fs) != 2 {
+		t.Fatalf("expected 2 split findings, got %d", len(fs))
+	}
+	for _, f := range fs {
+		if c := f.RecommendedSQL; len(c) == 0 || c[len(c)-1] != ';' {
+			t.Errorf("each finding should be a single statement: %q", f.RecommendedSQL)
+		}
+		if f.ObjectIdentifier == "instance" {
+			t.Error("split findings need distinct object identifiers")
+		}
+	}
+}

--- a/sidecar/internal/analyzer/coverage_boost_test.go
+++ b/sidecar/internal/analyzer/coverage_boost_test.go
@@ -2134,8 +2134,14 @@ func TestCoverage_SubsetFinding(t *testing.T) {
 	if f.Category != "duplicate_index" {
 		t.Errorf("Category = %q, want duplicate_index", f.Category)
 	}
-	if f.Severity != "critical" {
-		t.Errorf("Severity = %q, want critical", f.Severity)
+	// Subset drops are advisory: info severity + high_risk so they never
+	// auto-execute (auto-dropping a leading-prefix subset is a judgment call
+	// and fought app-managed indexes). Exact-duplicate drops stay auto/safe.
+	if f.Severity != "info" {
+		t.Errorf("Severity = %q, want info", f.Severity)
+	}
+	if f.ActionRisk != "high_risk" {
+		t.Errorf("ActionRisk = %q, want high_risk (advisory)", f.ActionRisk)
 	}
 	if f.ObjectIdentifier != "public.idx_sub" {
 		t.Errorf("ObjectIdentifier = %q, want public.idx_sub", f.ObjectIdentifier)

--- a/sidecar/internal/analyzer/rules_index.go
+++ b/sidecar/internal/analyzer/rules_index.go
@@ -359,7 +359,7 @@ func subsetFinding(
 ) Finding {
 	return Finding{
 		Category:         "duplicate_index",
-		Severity:         "critical",
+		Severity:         "info",
 		ObjectType:       "index",
 		ObjectIdentifier: subIdent,
 		Title: fmt.Sprintf(
@@ -371,12 +371,18 @@ func subsetFinding(
 			"subset_def":   sub.IndexDef,
 			"superset_def": sup.IndexDef,
 		},
-		Recommendation: "Drop subset index; the larger index covers it.",
+		Recommendation: "Subset index — likely covered by the larger index, " +
+			"but a dedicated narrow index can still be faster and may be " +
+			"app-managed. Review before dropping.",
 		RecommendedSQL: fmt.Sprintf(
 			"DROP INDEX CONCURRENTLY %s;", subIdent,
 		),
 		RollbackSQL: sub.IndexDef + ";",
-		ActionRisk:  "safe",
+		// Advisory only: a leading-prefix subset drop is a judgment call
+		// (read-perf trade-off, and apps that re-create their own indexes
+		// turn an auto-drop into an oscillation). high_risk never
+		// auto-executes — exact-duplicate drops stay auto (safe).
+		ActionRisk: "high_risk",
 	}
 }
 

--- a/sidecar/internal/fleet/manager.go
+++ b/sidecar/internal/fleet/manager.go
@@ -222,25 +222,30 @@ func (m *DatabaseManager) setEmergencyStopped(
 		if name != "" && name != n {
 			continue
 		}
-		if inst.Stopped != stopped {
-			if inst.Pool != nil {
-				ctx, cancel := context.WithTimeout(
-					context.Background(), 5*time.Second,
-				)
-				err := executor.SetEmergencyStop(ctx, inst.Pool, stopped)
-				cancel()
-				if err != nil {
-					return changed, fmt.Errorf(
-						"persisting emergency stop for %s: %w", n, err)
-				}
+		// Always reconcile the persistent flag (sage.config) with the
+		// target, even when the in-memory state already matches. After a
+		// restart the in-memory state resets to "running" while the
+		// persisted flag may still be "stopped"; gating the write on the
+		// in-memory state left resume unable to clear it.
+		if inst.Pool != nil {
+			ctx, cancel := context.WithTimeout(
+				context.Background(), 5*time.Second,
+			)
+			err := executor.SetEmergencyStop(ctx, inst.Pool, stopped)
+			cancel()
+			if err != nil {
+				return changed, fmt.Errorf(
+					"persisting emergency stop for %s: %w", n, err)
 			}
-			inst.Stopped = stopped
-			changed++
+		}
+		if inst.Stopped != stopped {
 			if stopped {
 				log.Printf("fleet: %s: emergency stop", n)
 			} else {
 				log.Printf("fleet: %s: resumed", n)
 			}
+			inst.Stopped = stopped
+			changed++
 		}
 	}
 	return changed, nil


### PR DESCRIPTION
Three fixes from running autonomous on a real app-managed DB:
- **Subset-index drops advisory** (never auto) — auto-dropping leading-prefix subsets fought an app re-creating its own indexes (oscillation). Exact-duplicate drops stay auto.
- **Multi-statement config split** — WAL tuning's 3 `ALTER SYSTEM` statements are split into atomic per-param actions instead of being rejected as multi-statement.
- **Resume after restart** — `setEmergencyStopped` now always reconciles the persisted `emergency_stop` flag (was a no-op when in-memory already matched, leaving the executor stuck stopped after a restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)