### PR TITLE
fix: autonomous index + config actions land end-to-end (5 pipeline bugs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,28 @@
 
 ### Fixed
 
+- **Config reloads can execute.** `SELECT pg_reload_conf()` is now on the
+  executor's SELECT allowlist, so the apply-step after an autonomous
+  `ALTER SYSTEM` actually takes effect instead of failing validation.
+- **No more orphan reload findings.** When an advisor recommendation bundles
+  `ALTER SYSTEM ...; SELECT pg_reload_conf();`, the reload (an apply
+  mechanism the executor performs itself) is dropped from the statement
+  split rather than becoming its own unexecutable finding.
+- **Optimizer index recommendations auto-execute.** LLM index recs
+  (missing/composite/covering/GIN/HNSW) are now deterministically classified
+  `moderate` — `CREATE INDEX CONCURRENTLY` is online and reversible — so
+  they run autonomously under the moderate trust gate instead of being
+  stuck advisory behind the LLM's self-rated `high_risk`. Index DROPs keep
+  their conservative rating.
+- **GIN/HNSW DDL passes validation.** The column-existence check now strips
+  operator-class specifiers (`payload jsonb_path_ops`,
+  `embedding vector_l2_ops`) instead of rejecting them as nonexistent
+  columns.
+- **Optimizer indexes no longer self-destruct.** The INCLUDE-upgrade path
+  consumed `drop_ddl` — which doubles as the new index's own rollback — and
+  dropped the index it had just created. A self-reference guard now skips
+  the upgrade drop when it targets the newly created index; rollback remains
+  the job of the post-action monitor.
 - **Subset-index drops are advisory now.** A leading-prefix "subset" index
   (`(c1)` covered by `(c1, c2)`) is no longer auto-dropped — it's a judgment
   call (read-perf trade-off, and apps that re-create their own indexes turn an

--- a/demo/run_demo.py
+++ b/demo/run_demo.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""pg_sage capability demo — setup + load generator.
+
+Creates the `pgsage_demo` database on the health_pg container, seeds the
+capability scenarios (seed.sql), and then hammers the read queries so they
+accumulate in pg_stat_statements where pg_sage's optimizer/advisor can see
+them. Each query is sent as a TOP-LEVEL statement (pg_stat_statements default
+track='top' ignores nested EXECUTE), so the load is generated client-side and
+piped to psql.
+
+Usage:
+    python run_demo.py --setup          # create db + run seed.sql (one time)
+    python run_demo.py                  # one round of load
+    python run_demo.py --rounds 5       # keep totals climbing for a few min
+    python run_demo.py --setup --rounds 3
+
+Everything runs through `docker exec health_pg psql` so no local driver or
+psql client is required.
+"""
+import argparse
+import os
+import random
+import subprocess
+import sys
+import time
+
+CONTAINER = "health_pg"
+DB = "pgsage_demo"
+SEED_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "seed.sql")
+
+
+def psql(dbname, sql, ignore_errors=True):
+    """Pipe a SQL buffer to psql inside the container; return (rc, out)."""
+    flags = "-q" if ignore_errors else "-q -v ON_ERROR_STOP=1"
+    cmd = [
+        "docker", "exec", "-i", CONTAINER,
+        "psql", "-U", "postgres", "-d", dbname, "-X",
+    ] + flags.split()
+    proc = subprocess.run(cmd, input=sql, capture_output=True,
+                          text=True, encoding="utf-8", errors="replace")
+    return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+
+
+def setup():
+    print(f"[setup] creating database {DB} ...")
+    # CREATE DATABASE must not run inside a txn block; psql sends it standalone.
+    rc, out = psql("postgres",
+                   f"DROP DATABASE IF EXISTS {DB} WITH (FORCE);\n"
+                   f"CREATE DATABASE {DB};\n")
+    if "ERROR" in out:
+        print(out)
+    with open(SEED_FILE, "r", encoding="utf-8") as f:
+        seed = f.read()
+    print(f"[setup] seeding scenarios from {os.path.basename(SEED_FILE)} ...")
+    rc, out = psql(DB, seed, ignore_errors=False)
+    print(out.strip()[-2000:])
+    if rc != 0:
+        print("[setup] seed FAILED", file=sys.stderr)
+        sys.exit(1)
+    print("[setup] done.")
+
+
+def rand_vec(dim=256):
+    return "[" + ",".join(f"{random.random():.4f}" for _ in range(dim)) + "]"
+
+
+def build_load_sql():
+    """One round of mixed top-level queries hitting every scenario."""
+    parts = []
+    types = ["click", "view", "purchase", "signup", "logout"]
+    regions = ["NA", "EU", "APAC", "LATAM"]
+    statuses = ["pending", "paid", "shipped", "cancelled"]
+
+    # A — missing index on orders.customer_id (point lookups, seq scan).
+    for _ in range(120):
+        cid = random.randint(1, 5000)
+        parts.append(
+            f"SELECT count(*), sum(total_cents) FROM orders "
+            f"WHERE customer_id = {cid};")
+
+    # B — unindexed FK join orders <-> order_items.
+    for _ in range(60):
+        cid = random.randint(1, 5000)
+        parts.append(
+            f"SELECT count(*) FROM orders o JOIN order_items i "
+            f"ON i.order_id = o.id WHERE o.customer_id = {cid};")
+
+    # C — jsonb containment (wants a GIN index).
+    for _ in range(80):
+        t = random.choice(types)
+        parts.append(
+            f"SELECT count(*) FROM events "
+            f"WHERE payload @> '{{\"type\":\"{t}\"}}'::jsonb;")
+
+    # D — vector KNN (wants an HNSW index).
+    for _ in range(40):
+        parts.append(
+            f"SELECT id FROM documents "
+            f"ORDER BY embedding <-> '{rand_vec()}'::vector LIMIT 10;")
+
+    # E — big GROUP BY / sort that spills at work_mem=64kB (wants more work_mem).
+    for _ in range(25):
+        parts.append(
+            "SELECT customer_id, count(*) c, sum(total_cents) s FROM orders "
+            "GROUP BY customer_id ORDER BY s DESC LIMIT 50;")
+
+    # F — 3-way join with selective filters (query-rewrite / join-hint candidate).
+    for _ in range(40):
+        r = random.choice(regions)
+        s = random.choice(statuses)
+        parts.append(
+            "SELECT o.id, c.name, i.sku "
+            "FROM orders o JOIN customers c ON c.id = o.customer_id "
+            "JOIN order_items i ON i.order_id = o.id "
+            f"WHERE c.region = '{r}' AND o.status = '{s}' LIMIT 100;")
+
+    random.shuffle(parts)
+    return "\n".join(parts) + "\n"
+
+
+def load_round(n):
+    sql = build_load_sql()
+    t0 = time.time()
+    rc, out = psql(DB, sql)
+    dt = time.time() - t0
+    errs = out.count("ERROR")
+    print(f"[load] round {n}: {sql.count(';')} queries in {dt:.1f}s"
+          + (f"  ({errs} errors)" if errs else ""))
+    if errs:
+        # surface the first error so problems aren't silent
+        for line in out.splitlines():
+            if "ERROR" in line:
+                print("       " + line)
+                break
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--setup", action="store_true",
+                    help="(re)create + seed the pgsage_demo database first")
+    ap.add_argument("--rounds", type=int, default=1,
+                    help="how many load rounds to run (default 1)")
+    ap.add_argument("--sleep", type=float, default=20.0,
+                    help="seconds between rounds (default 20)")
+    args = ap.parse_args()
+
+    if args.setup:
+        setup()
+
+    for i in range(1, args.rounds + 1):
+        load_round(i)
+        if i < args.rounds:
+            time.sleep(args.sleep)
+    print("[done] pg_stat_statements populated — pg_sage will analyze on its "
+          "next cycle (~60s).")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/seed.sql
+++ b/demo/seed.sql
@@ -1,0 +1,151 @@
+-- pg_sage capability demo — seed schema + data.
+-- Run against a fresh `pgsage_demo` database on the health_pg container
+-- (PG16 + timescaledb, has pg_stat_statements preloaded, vector, btree_gin).
+--
+-- Each block sets up ONE scenario that pg_sage should detect and act on.
+-- The companion load generator (run_demo.py) hammers the read queries so
+-- they land in pg_stat_statements for the optimizer/advisor to analyze.
+--
+-- Idempotent: safe to re-run (drops and recreates everything).
+
+\set ON_ERROR_STOP on
+
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS btree_gin;
+
+SELECT pg_stat_statements_reset();
+
+DROP TABLE IF EXISTS order_items, orders, events, documents, customers CASCADE;
+
+-- ---------------------------------------------------------------------------
+-- customers — small dimension table (join target). Indexed PK only.
+-- ---------------------------------------------------------------------------
+CREATE TABLE customers (
+    id        bigserial PRIMARY KEY,
+    name      text NOT NULL,
+    region    text NOT NULL,
+    tier      text NOT NULL
+);
+INSERT INTO customers (name, region, tier)
+SELECT 'customer ' || g,
+       (ARRAY['NA','EU','APAC','LATAM'])[1 + (g % 4)],
+       (ARRAY['free','pro','enterprise'])[1 + (g % 3)]
+FROM generate_series(1, 5000) g;
+
+-- ---------------------------------------------------------------------------
+-- Scenario A — MISSING INDEX → CREATE INDEX (auto, safe).
+-- Scenario H — STALE STATS  → ANALYZE (auto).
+-- Scenario I — DEAD TUPLES  → VACUUM  (auto).
+-- orders has 500k rows, no index on customer_id (hot filter column).
+-- autovacuum disabled so stats stay stale and dead tuples accumulate,
+-- guaranteeing the VACUUM + ANALYZE findings fire instead of being
+-- silently cleaned up by the autovacuum daemon mid-demo.
+-- ---------------------------------------------------------------------------
+CREATE TABLE orders (
+    id           bigserial PRIMARY KEY,
+    customer_id  bigint NOT NULL,
+    status       text   NOT NULL,
+    total_cents  bigint NOT NULL,
+    created_at   timestamptz NOT NULL DEFAULT now()
+) WITH (autovacuum_enabled = false);
+
+INSERT INTO orders (customer_id, status, total_cents, created_at)
+SELECT 1 + (random() * 4999)::bigint,
+       (ARRAY['pending','paid','shipped','cancelled'])[1 + (g % 4)],
+       (random() * 50000)::bigint,
+       now() - (random() * interval '365 days')
+FROM generate_series(1, 500000) g;
+
+-- Scenario G — DUPLICATE INDEX → DROP INDEX (auto, safe).
+-- Two byte-identical indexes on orders.status; pg_sage drops one.
+CREATE INDEX idx_orders_status_a ON orders (status);
+CREATE INDEX idx_orders_status_b ON orders (status);
+
+-- Churn: create dead tuples + bump n_mod_since_analyze (no autovacuum here).
+UPDATE orders SET status = 'paid'      WHERE id % 5 = 0;
+UPDATE orders SET total_cents = total_cents + 1 WHERE id % 7 = 0;
+DELETE FROM orders WHERE id % 50 = 0;
+
+-- ---------------------------------------------------------------------------
+-- Scenario B — MISSING FK INDEX → CREATE INDEX (auto, safe).
+-- order_items.order_id is a foreign key with NO supporting index — the
+-- classic "unindexed FK" that makes parent deletes and joins slow.
+-- ---------------------------------------------------------------------------
+CREATE TABLE order_items (
+    id        bigserial PRIMARY KEY,
+    order_id  bigint NOT NULL REFERENCES orders (id),
+    sku       text   NOT NULL,
+    qty       int    NOT NULL
+);
+-- Sample order_id from orders that actually survived the churn above, so the
+-- FK is always satisfied (~1.6 items/order, all pointing at live parents).
+INSERT INTO order_items (order_id, sku, qty)
+SELECT o.id,
+       'SKU-' || (1 + (random() * 2000)::int),
+       1 + (random() * 9)::int
+FROM orders o
+CROSS JOIN generate_series(1, 2) g
+WHERE random() < 0.8;
+
+-- ---------------------------------------------------------------------------
+-- Scenario C — GIN INDEX FOR JSONB → CREATE INDEX USING gin (optimizer).
+-- events.payload is queried with the @> containment operator; without a
+-- GIN index every lookup is a full seq scan.
+-- ---------------------------------------------------------------------------
+CREATE TABLE events (
+    id         bigserial PRIMARY KEY,
+    payload    jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+INSERT INTO events (payload, created_at)
+SELECT jsonb_build_object(
+           'type',    (ARRAY['click','view','purchase','signup','logout'])[1 + (g % 5)],
+           'user_id', 1 + (random() * 5000)::int,
+           'source',  (ARRAY['web','ios','android','api'])[1 + (g % 4)],
+           'amount',  (random() * 500)::numeric(10,2)
+       ),
+       now() - (random() * interval '90 days')
+FROM generate_series(1, 300000) g;
+
+-- ---------------------------------------------------------------------------
+-- Scenario D — HNSW INDEX FOR VECTOR → CREATE INDEX USING hnsw (optimizer).
+-- documents.embedding is queried with nearest-neighbour ORDER BY <-> LIMIT,
+-- but has no vector index, forcing a full scan + exact distance on every row.
+-- ---------------------------------------------------------------------------
+CREATE TABLE documents (
+    id        bigserial PRIMARY KEY,
+    title     text NOT NULL,
+    embedding vector(256) NOT NULL
+);
+
+CREATE OR REPLACE FUNCTION demo_rand_vec(dim int)
+RETURNS vector LANGUAGE sql VOLATILE AS $$
+    SELECT (SELECT array_agg(random())::vector
+            FROM generate_series(1, dim));
+$$;
+
+INSERT INTO documents (title, embedding)
+SELECT 'document ' || g, demo_rand_vec(256)
+FROM generate_series(1, 20000) g;
+
+-- ---------------------------------------------------------------------------
+-- Scenario E — work_mem BUMP → ALTER SYSTEM SET work_mem (memory advisor).
+-- Pin this database's work_mem tiny so the big GROUP BY / sort in the load
+-- generator spills to temp files, which the memory advisor flags.
+-- ---------------------------------------------------------------------------
+ALTER DATABASE pgsage_demo SET work_mem = '64kB';
+
+-- Refresh planner stats for the dimension tables we DO want indexed/analyzed
+-- (orders is intentionally left stale for Scenario H).
+ANALYZE customers;
+ANALYZE order_items;
+ANALYZE events;
+ANALYZE documents;
+
+SELECT 'seed complete' AS status,
+       (SELECT count(*) FROM orders)      AS orders,
+       (SELECT count(*) FROM order_items) AS order_items,
+       (SELECT count(*) FROM events)      AS events,
+       (SELECT count(*) FROM documents)   AS documents,
+       (SELECT count(*) FROM customers)   AS customers;

--- a/local_monitor_config.yaml
+++ b/local_monitor_config.yaml
@@ -110,6 +110,15 @@ databases:
     sslmode: disable
     tags: [local, docker, timescale, lifeos, legacy]
 
+  - name: pgsage_demo
+    host: 127.0.0.1
+    port: 5436
+    user: postgres
+    password: postgres
+    database: pgsage_demo
+    sslmode: disable
+    tags: [local, docker, demo, showcase]
+
   - name: lifeos_postgres_lifeos
     host: 127.0.0.1
     port: 5440

--- a/sidecar/internal/advisor/advisor_coverage_test.go
+++ b/sidecar/internal/advisor/advisor_coverage_test.go
@@ -522,6 +522,36 @@ func TestParseLLMFindings_NullRecommendedSQL(t *testing.T) {
 	}
 }
 
+func TestParseLLMFindings_DropsReloadFromMultiStatement(t *testing.T) {
+	// A config rec that bundles the apply mechanism must yield only the
+	// real tuning statement — the executor issues the reload itself.
+	raw := `[{"category":"memory_tuning","object_identifier":"instance",` +
+		`"recommended_sql":"ALTER SYSTEM SET work_mem = '64MB'; ` +
+		`SELECT pg_reload_conf();"}]`
+	findings := parseLLMFindings(raw, "test", noopLog)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding (reload dropped), got %d", len(findings))
+	}
+	got := findings[0].RecommendedSQL
+	if !strings.Contains(strings.ToUpper(got), "ALTER SYSTEM SET WORK_MEM") {
+		t.Fatalf("expected the ALTER SYSTEM statement, got %q", got)
+	}
+	if strings.Contains(strings.ToUpper(got), "PG_RELOAD_CONF") {
+		t.Fatalf("reload mechanism must not appear in finding SQL: %q", got)
+	}
+}
+
+func TestParseLLMFindings_BareReloadProducesNoFinding(t *testing.T) {
+	// A recommendation that is ONLY the apply mechanism is not an
+	// actionable tuning finding and must be dropped entirely (no orphan).
+	raw := `[{"category":"memory_tuning","object_identifier":"instance",` +
+		`"recommended_sql":"SELECT pg_reload_conf();"}]`
+	findings := parseLLMFindings(raw, "test", noopLog)
+	if len(findings) != 0 {
+		t.Fatalf("expected 0 findings for bare reload, got %d", len(findings))
+	}
+}
+
 func TestParseLLMFindings_NumericSeverityIgnored(t *testing.T) {
 	raw := `[{"object_identifier":"x","severity":5}]`
 	findings := parseLLMFindings(raw, "test", noopLog)

--- a/sidecar/internal/advisor/prompt.go
+++ b/sidecar/internal/advisor/prompt.go
@@ -68,7 +68,17 @@ func parseLLMFindings(
 		// single statement keeps its original shape (no behavior change).
 		stmts := splitSQLStatements(recSQL)
 		multi := len(stmts) > 1
-		if !multi {
+		if len(stmts) == 0 {
+			if rawStatementCount(recSQL) > 0 {
+				// recSQL was non-empty but only an apply mechanism
+				// (e.g. a bare reload) — nothing actionable to record.
+				continue
+			}
+			// Empty/null recommended_sql — preserve the original
+			// behavior: one advisory finding carrying no SQL.
+			stmts = []string{recSQL}
+		} else if !multi && rawStatementCount(recSQL) == 1 {
+			// Single statement to begin with — keep its verbatim shape.
 			stmts = []string{recSQL}
 		}
 		for _, stmt := range stmts {
@@ -109,14 +119,40 @@ func parseLLMFindings(
 // splitSQLStatements splits a recommendation into individual statements,
 // preserving a single statement unchanged. Each returned statement ends
 // with a semicolon so it is a complete, single-statement action.
+//
+// Config-apply mechanism statements (e.g. SELECT pg_reload_conf()) are
+// dropped: they are not independent recommendations, and the executor
+// already issues the reload itself after an ALTER SYSTEM via config_apply.
+// Emitting one as its own finding would create an orphan action that
+// reloads nothing meaningful on its own.
 func splitSQLStatements(sql string) []string {
 	var out []string
 	for _, s := range strings.Split(sql, ";") {
-		if s = strings.TrimSpace(s); s != "" {
+		if s = strings.TrimSpace(s); s != "" && !isApplyMechanism(s) {
 			out = append(out, s+";")
 		}
 	}
 	return out
+}
+
+// isApplyMechanism reports whether a statement is a config-apply mechanism
+// the executor performs automatically, rather than a tuning recommendation.
+func isApplyMechanism(stmt string) bool {
+	u := strings.ToUpper(strings.TrimSpace(stmt))
+	return strings.HasPrefix(u, "SELECT PG_RELOAD_CONF")
+}
+
+// rawStatementCount counts non-empty statements in the recommendation as
+// the LLM emitted it, including apply mechanisms. Used to decide whether a
+// single post-filter statement should keep its original verbatim shape.
+func rawStatementCount(sql string) int {
+	n := 0
+	for _, s := range strings.Split(sql, ";") {
+		if strings.TrimSpace(s) != "" {
+			n++
+		}
+	}
+	return n
 }
 
 // deriveActionRisk returns the risk level for a recommended SQL

--- a/sidecar/internal/executor/executor.go
+++ b/sidecar/internal/executor/executor.go
@@ -606,9 +606,13 @@ func (e *Executor) executeFinding(
 		}
 	}
 
-	// Handle INCLUDE upgrade: DROP old index after verifying new one.
+	// Handle INCLUDE upgrade: DROP the SUPERSEDED (old) index after verifying
+	// the new one. drop_ddl doubles as the new index's own rollback
+	// (RollbackSQL), so skip it when it targets the index we just created —
+	// that case is a rollback, handled by MonitorAndRollback below, not an
+	// upgrade. Dropping it here would undo every optimizer index immediately.
 	if dropOld, ok := f.Detail["drop_ddl"].(string); ok &&
-		dropOld != "" {
+		dropOld != "" && !isSelfReferentialDrop(f.RecommendedSQL, dropOld) {
 		idxName := extractIndexName(f.RecommendedSQL)
 		valid, checkErr := optimizer.CheckIndexValid(
 			ctx, e.pool, idxName,
@@ -1031,6 +1035,9 @@ func extractIndexName(sql string) string {
 	}
 	if strings.HasPrefix(upper, "IF NOT EXISTS") {
 		rest = strings.TrimSpace(rest[len("IF NOT EXISTS"):])
+	} else if strings.HasPrefix(upper, "IF EXISTS") {
+		// DROP INDEX CONCURRENTLY IF EXISTS <name>
+		rest = strings.TrimSpace(rest[len("IF EXISTS"):])
 	}
 	// Next token is the index name.
 	fields := strings.Fields(rest)
@@ -1042,4 +1049,28 @@ func extractIndexName(sql string) string {
 	}
 	name := strings.Trim(fields[0], "\"")
 	return name
+}
+
+// unqualifyIndexName reduces a possibly schema-qualified, quoted, or
+// semicolon-terminated index reference to a bare lowercase name for
+// comparison (e.g. `public."idx_x";` -> `idx_x`).
+func unqualifyIndexName(name string) string {
+	name = strings.TrimSpace(name)
+	name = strings.TrimSuffix(name, ";")
+	name = strings.Trim(name, "\"")
+	if i := strings.LastIndex(name, "."); i >= 0 {
+		name = name[i+1:]
+	}
+	return strings.ToLower(strings.Trim(name, "\""))
+}
+
+// isSelfReferentialDrop reports whether dropDDL drops the same index that
+// createSQL creates. The optimizer reuses a recommendation's rollback DDL
+// (a DROP of the NEW index) as Detail["drop_ddl"], so the INCLUDE-upgrade
+// path must skip it — otherwise it would immediately drop the index it just
+// created. A genuine supersede targets a different, pre-existing index.
+func isSelfReferentialDrop(createSQL, dropDDL string) bool {
+	c := unqualifyIndexName(extractIndexName(createSQL))
+	d := unqualifyIndexName(extractIndexName(dropDDL))
+	return c != "" && c == d
 }

--- a/sidecar/internal/executor/executor_new_test.go
+++ b/sidecar/internal/executor/executor_new_test.go
@@ -225,6 +225,11 @@ func TestExtractIndexName_Table(t *testing.T) {
 			sql:  "SELECT 1",
 			want: "",
 		},
+		{
+			name: "DROP INDEX CONCURRENTLY IF EXISTS",
+			sql:  "DROP INDEX CONCURRENTLY IF EXISTS idx_foo",
+			want: "idx_foo",
+		},
 	}
 
 	for _, tc := range tests {
@@ -233,6 +238,51 @@ func TestExtractIndexName_Table(t *testing.T) {
 			if got != tc.want {
 				t.Errorf("extractIndexName(%q) = %q, want %q",
 					tc.sql, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsSelfReferentialDrop(t *testing.T) {
+	tests := []struct {
+		name      string
+		createSQL string
+		dropDDL   string
+		want      bool
+	}{
+		{
+			name:      "rollback drops the index just created (GIN)",
+			createSQL: "CREATE INDEX CONCURRENTLY idx_events_payload_path_ops " +
+				"ON public.events USING gin (payload jsonb_path_ops)",
+			dropDDL: "DROP INDEX CONCURRENTLY IF EXISTS idx_events_payload_path_ops",
+			want:    true,
+		},
+		{
+			name:      "rollback with schema + semicolon still matches",
+			createSQL: "CREATE INDEX CONCURRENTLY documents_embedding_hnsw_idx " +
+				"ON public.documents USING hnsw (embedding vector_l2_ops)",
+			dropDDL: "DROP INDEX CONCURRENTLY IF EXISTS public.documents_embedding_hnsw_idx;",
+			want:    true,
+		},
+		{
+			name:      "genuine supersede targets a different old index",
+			createSQL: "CREATE INDEX CONCURRENTLY idx_orders_cust_incl " +
+				"ON public.orders (customer_id) INCLUDE (total_cents)",
+			dropDDL: "DROP INDEX CONCURRENTLY IF EXISTS idx_orders_cust_old",
+			want:    false,
+		},
+		{
+			name:      "empty drop is not self-referential",
+			createSQL: "CREATE INDEX CONCURRENTLY idx_a ON t (c)",
+			dropDDL:   "",
+			want:      false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSelfReferentialDrop(tc.createSQL, tc.dropDDL); got != tc.want {
+				t.Errorf("isSelfReferentialDrop(%q, %q) = %v, want %v",
+					tc.createSQL, tc.dropDDL, got, tc.want)
 			}
 		})
 	}

--- a/sidecar/internal/executor/validate.go
+++ b/sidecar/internal/executor/validate.go
@@ -71,6 +71,10 @@ var safeAlterSystemParams = map[string]bool{
 var allowedSelectPatterns = []string{
 	"SELECT PG_TERMINATE_BACKEND(",
 	"SELECT PG_CANCEL_BACKEND(",
+	// pg_reload_conf() is how the config-apply path makes an ALTER SYSTEM
+	// change take effect (re-reads postgresql.conf/.auto.conf). It only
+	// signals the postmaster and returns a boolean — no destructive effect.
+	"SELECT PG_RELOAD_CONF(",
 }
 
 // safeAlterTableSubcmds restricts ALTER TABLE to safe
@@ -184,8 +188,8 @@ func checkSelectPattern(upper string) error {
 		}
 	}
 	return fmt.Errorf(
-		"%w: only pg_terminate_backend and pg_cancel_backend "+
-			"SELECT statements are allowed",
+		"%w: only pg_terminate_backend, pg_cancel_backend and "+
+			"pg_reload_conf SELECT statements are allowed",
 		ErrDisallowedSQL,
 	)
 }

--- a/sidecar/internal/executor/validate_test.go
+++ b/sidecar/internal/executor/validate_test.go
@@ -22,6 +22,9 @@ func TestValidateSQL_AllowedStatements(t *testing.T) {
 		"RESET lock_timeout",
 		"SELECT pg_terminate_backend(12345)",
 		"SELECT pg_cancel_backend(12345)",
+		// reload after ALTER SYSTEM must be allowed or config changes
+		// never take effect autonomously.
+		"SELECT pg_reload_conf()",
 		"  CREATE INDEX idx ON t(id)  ",
 		"create index concurrently idx on t(id)",
 	}

--- a/sidecar/internal/optimizer/optimizer_test.go
+++ b/sidecar/internal/optimizer/optimizer_test.go
@@ -106,6 +106,22 @@ func TestExtractColumnsFromDDL(t *testing.T) {
 			"CREATE INDEX idx ON t (a) INCLUDE (b, c)",
 			[]string{"a"},
 		},
+		{
+			// GIN with an operator class — column is "payload", not
+			// "payload jsonb_path_ops".
+			"CREATE INDEX CONCURRENTLY ON e USING gin (payload jsonb_path_ops)",
+			[]string{"payload"},
+		},
+		{
+			// HNSW vector index — column is "embedding".
+			"CREATE INDEX CONCURRENTLY ON d USING hnsw (embedding vector_l2_ops)",
+			[]string{"embedding"},
+		},
+		{
+			// opclass + sort direction together.
+			"CREATE INDEX idx ON t (name text_pattern_ops DESC)",
+			[]string{"name"},
+		},
 	}
 	for _, tt := range tests {
 		got := extractColumnsFromDDL(tt.ddl)

--- a/sidecar/internal/optimizer/risk.go
+++ b/sidecar/internal/optimizer/risk.go
@@ -10,9 +10,21 @@ const (
 
 // RiskTierForRecommendation returns the executor policy risk for an index
 // recommendation. ActionLevel is confidence/exposure metadata, not risk.
+//
+// Index CREATE (including GIN/HNSW/composite/covering) is classified
+// deterministically as MODERATE rather than trusting the LLM's self-rated
+// action_risk: CREATE INDEX CONCURRENTLY is online and reversible (a plain
+// DROP INDEX), so it is appropriate for autonomous execution under the
+// moderate gate (31-day ramp + maintenance window). Index DROPs and all
+// other recommendations keep the LLM/action-level risk — drops stay
+// advisory because removing an index can regress queries.
 func RiskTierForRecommendation(rec Recommendation) string {
-	if strings.TrimSpace(rec.DDL) == "" {
+	ddl := strings.TrimSpace(rec.DDL)
+	if ddl == "" {
 		return ""
+	}
+	if isIndexCreate(ddl) {
+		return RiskModerate
 	}
 	switch strings.ToLower(strings.TrimSpace(rec.ActionRisk)) {
 	case RiskSafe:
@@ -26,6 +38,14 @@ func RiskTierForRecommendation(rec Recommendation) string {
 	default:
 		return RiskHigh
 	}
+}
+
+// isIndexCreate reports whether the DDL creates an index (btree, GIN, GiST,
+// HNSW, IVFFlat, unique, partial, covering — any CREATE [UNIQUE] INDEX).
+func isIndexCreate(ddl string) bool {
+	u := strings.ToUpper(strings.TrimSpace(ddl))
+	return strings.HasPrefix(u, "CREATE INDEX") ||
+		strings.HasPrefix(u, "CREATE UNIQUE INDEX")
 }
 
 func riskFromActionLevel(level string) string {

--- a/sidecar/internal/optimizer/risk_test.go
+++ b/sidecar/internal/optimizer/risk_test.go
@@ -3,6 +3,8 @@ package optimizer
 import "testing"
 
 func TestRiskTierForRecommendation_ActionLevelsMapToModerate(t *testing.T) {
+	// Non-index-create DDL with no explicit risk falls back to the action
+	// level, which maps to moderate for these levels.
 	tests := []struct {
 		name        string
 		actionLevel string
@@ -16,7 +18,7 @@ func TestRiskTierForRecommendation_ActionLevelsMapToModerate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rec := Recommendation{
-				DDL:         "CREATE INDEX CONCURRENTLY idx ON t (id)",
+				DDL:         "DROP INDEX CONCURRENTLY idx",
 				ActionLevel: tt.actionLevel,
 			}
 
@@ -30,13 +32,36 @@ func TestRiskTierForRecommendation_ActionLevelsMapToModerate(t *testing.T) {
 	}
 }
 
+func TestRiskTierForRecommendation_IndexCreateAlwaysModerate(t *testing.T) {
+	// CREATE INDEX (any access method, any self-rated risk) is moderate so
+	// it can run autonomously — online + reversible. This must override even
+	// an LLM-inflated high_risk or an unknown self-rating.
+	ddls := []string{
+		"CREATE INDEX CONCURRENTLY idx ON t (id)",
+		"CREATE INDEX CONCURRENTLY ON e USING gin (payload jsonb_path_ops)",
+		"CREATE INDEX CONCURRENTLY ON d USING hnsw (embedding vector_l2_ops)",
+		"CREATE UNIQUE INDEX CONCURRENTLY uq ON t (email)",
+	}
+	for _, risk := range []string{"", RiskSafe, RiskModerate, RiskHigh, "maybe"} {
+		for _, ddl := range ddls {
+			rec := Recommendation{DDL: ddl, ActionRisk: risk}
+			if got := RiskTierForRecommendation(rec); got != RiskModerate {
+				t.Fatalf("index create %q (self-rated %q) = %q, want moderate",
+					ddl, risk, got)
+			}
+		}
+	}
+}
+
 func TestRiskTierForRecommendation_ExplicitRiskPassesThrough(t *testing.T) {
+	// For non-index-create DDL (e.g. DROP INDEX), the self-rated risk is
+	// honored verbatim.
 	tests := []string{RiskSafe, RiskModerate, RiskHigh}
 
 	for _, want := range tests {
 		t.Run(want, func(t *testing.T) {
 			rec := Recommendation{
-				DDL:        "CREATE INDEX CONCURRENTLY idx ON t (id)",
+				DDL:        "DROP INDEX CONCURRENTLY idx",
 				ActionRisk: want,
 			}
 
@@ -51,8 +76,10 @@ func TestRiskTierForRecommendation_ExplicitRiskPassesThrough(t *testing.T) {
 }
 
 func TestRiskTierForRecommendation_UnknownRiskFailsClosed(t *testing.T) {
+	// A non-index-create DDL with an unrecognized self-rating fails closed
+	// to high_risk (advisory only).
 	rec := Recommendation{
-		DDL:        "CREATE INDEX CONCURRENTLY idx ON t (id)",
+		DDL:        "DROP INDEX CONCURRENTLY idx",
 		ActionRisk: "maybe_safe",
 	}
 

--- a/sidecar/internal/optimizer/validate.go
+++ b/sidecar/internal/optimizer/validate.go
@@ -261,11 +261,30 @@ func extractColumnsFromDDL(ddl string) []string {
 		col := strings.TrimSpace(part)
 		col = strings.Trim(col, "\"")
 		col = stripSortDirection(col)
+		col = stripOperatorClass(col)
 		if col != "" {
 			cols = append(cols, col)
 		}
 	}
 	return cols
+}
+
+// stripOperatorClass removes a trailing operator-class specifier from an
+// index column entry — e.g. "payload jsonb_path_ops" -> "payload",
+// "embedding vector_l2_ops" -> "embedding". Every Postgres operator class
+// name ends in "_ops", so the strip is precise: it only fires on a bare
+// "<column> <something>_ops" pair, leaving plain columns and expression
+// entries (which contain parentheses) untouched.
+func stripOperatorClass(col string) string {
+	if strings.ContainsAny(col, "()") {
+		return col
+	}
+	fields := strings.Fields(col)
+	if len(fields) == 2 &&
+		strings.HasSuffix(strings.ToLower(fields[1]), "_ops") {
+		return fields[0]
+	}
+	return col
 }
 
 func stripSortDirection(col string) string {


### PR DESCRIPTION
Demo-case setup surfaced five bugs between *finding created* and *action in effect*:

1. **pg_reload_conf blocked by validator** — apply step after ALTER SYSTEM always failed.
2. **Orphan reload findings** — multi-statement split turned the reload into its own dead finding.
3. **Optimizer index recs never auto-ran** — LLM self-rated them high_risk; now CREATE INDEX is deterministically moderate (online + reversible).
4. **GIN/HNSW DDL rejected** — opclass specifiers parsed as column names.
5. **Index self-drop** — INCLUDE-upgrade path consumed drop_ddl (the new index's own rollback) and dropped the index it just created, every cycle.

Verified live on pgsage_demo: GIN (jsonb), HNSW (vector), covering + FK btree indexes all created autonomously and persist; work_mem ALTER SYSTEM + reload, VACUUM, ANALYZE, dup-index drop all in the action log. Full Go suite green (36 pkgs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)