### PR TITLE
fix(collector): don't abort snapshot cycle on NULL pg_locks columns

### DIFF
--- a/sidecar/internal/collector/collector.go
+++ b/sidecar/internal/collector/collector.go
@@ -161,8 +161,15 @@ func (c *Collector) collect(ctx context.Context) (*Snapshot, error) {
 	if snap.System, err = c.collectSystem(ctx); err != nil {
 		return nil, err
 	}
+	// Non-fatal: pg_locks rows for non-client backends (autovacuum
+	// workers, replication workers) or advisory locks routinely carry
+	// NULL in columns such as state/wait_event/relname. A single such
+	// row must not abort the entire snapshot cycle, which would
+	// silently halt all stats collection (H1/H2) on any actively-used
+	// database. Match the WARN-and-continue behavior of the sibling
+	// collectors below.
 	if snap.Locks, err = c.collectLocks(ctx); err != nil {
-		return nil, err
+		c.logFn("WARN", "locks collection failed: %v", err)
 	}
 	if snap.Sequences, err = c.collectSequences(ctx); err != nil {
 		return nil, err


### PR DESCRIPTION
collectLocks() used fail-fast error handling, unlike sibling collectors (collectReplication, collectIO). A single row with a NULL column — routine for autovacuum/replication worker backends or advisory locks — aborted the entire snapshot cycle, silently halting all stats collection on any actively-used database.

Match the WARN-and-continue behavior already used by the sibling collectors below it.

This fixes Issue [41](https://github.com/jasonmassie01/pg_sage/issues/41)