### PR TITLE
fix(safety): harden audit findings for v1.3.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,6 @@ docker-entrypoint-initdb.d/ export-ignore
 .github/            export-ignore
 .gitattributes      export-ignore
 .gitignore          export-ignore
+
+# Byte-exact generated reference; tests compare it with Go generator output.
+docs/generated/config-lifecycles.md text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v1.3.1 (2026-07-22) -- Correctness and Safety Audit Follow-up
+
+### Fixed
+
+- Restricted LLM model discovery to administrators and blocked SSRF through
+  private, loopback, metadata, redirected, or DNS-rebound provider endpoints.
+- Scoped LLM cooldowns to logical work items, counted provider timeouts toward
+  circuit health, and prevented local admission throttles from poisoning
+  optimizer table circuit breakers.
+- Enforced atomic per-database token budgets across optimizer, advisor, tuner,
+  briefing, RCA, narration, justification, schema lint, and migration clients.
+- Restored fleet health-history samples, initialized fleet and meta-database
+  ANALYZE concurrency limits, and made AgentDB collectors process-owned and
+  drainable instead of inheriting a short reconciliation context.
+- Initialized the general LLM runtime in meta-database mode and wired scoped
+  LLM clients through every per-database consumer.
+- Made executor policy reads race-free during configuration hot reload.
+- Corrected cron maintenance windows to honor month, day-of-month, and
+  day-of-week semantics before autonomous moderate-risk maintenance.
+- Applied transaction-local statement and lock timeouts to collector catalog
+  reads, including early-error cleanup of pooled transactions.
+- Added safe on-demand EXPLAIN capture for normalized parameterized queries.
+- Clarified that interactive ReAct diagnosis belongs to the frozen C extension,
+  not the Go sidecar, and made generated lifecycle documentation byte-stable.
+
 ## v1.3 (2026-07-19) -- Correctness and Safety Remediation
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ docker logs pg_sage 2>&1 | grep 'INITIAL ADMIN PASSWORD'
 | **Rules Engine** | 20+ deterministic checks: duplicate/unused/missing indexes, slow queries, regressions, seq scans, vacuum & bloat, dead tuples, sequence exhaustion, replication lag, security audit, config drift |
 | **Index Optimizer** | LLM-powered recommendations validated through 8 checks + HypoPG cost estimation, confidence scored 0.0--1.0 |
 | **Config Advisors** | 6 LLM advisors: vacuum tuning, WAL/checkpoint, connections, memory, query rewrite, bloat remediation |
-| **Health Briefings** | Periodic LLM-generated summaries of database state; interactive diagnose via ReAct loop |
+| **Health Briefings** | Periodic LLM summaries. ReAct is C-extension-only via `sage.diagnose()`; it is not exposed by the Go sidecar. |
 | **Trust-Ramped Executor** | Observation -> Advisory -> Autonomous. Typed actions carry risk tier, guardrails, expiration, rollback/mitigation, and verification state. HIGH-risk actions always require approval. |
 | **Shadow Mode** | Shows avoided toil and proof rows for actions pg_sage would have handled under auto-safe policy before teams turn on autonomous execution |
 | **Fleet Mode** | Monitor N databases from one binary with per-database trust levels, token budgets, and health scores |

--- a/sidecar/cmd/pg_sage_sidecar/agentdb_fleet.go
+++ b/sidecar/cmd/pg_sage_sidecar/agentdb_fleet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/pg-sage/sidecar/internal/agentdb"
@@ -109,17 +110,30 @@ func connectAgentDBToFleet(
 	mgr *fleet.DatabaseManager,
 	dbCfg config.DatabaseConfig,
 ) {
+	if ctx != nil && ctx.Err() != nil {
+		return
+	}
 	pool, err := connectMonitoredDB(dbCfg.ConnString(), dbCfg.MaxConnections)
 	if err != nil {
 		logWarn("agentdb", "fleet sync: connect %q: %v", dbCfg.Name, err)
 		return
 	}
-	instCtx, cancel := context.WithCancel(ctx)
+	parent := agentDBRuntimeParent(ctx)
+	if parent.Err() != nil {
+		pool.Close()
+		return
+	}
+	instCtx, cancel := context.WithCancel(parent)
+	workers := &sync.WaitGroup{}
+	dbColl := collector.New(pool, cfg, detectPGVersion(pool),
+		logStructuredWrapper)
 	inst := &fleet.DatabaseInstance{
-		Name:   dbCfg.Name,
-		Config: dbCfg,
-		Pool:   pool,
-		Cancel: cancel,
+		Name:      dbCfg.Name,
+		Config:    dbCfg,
+		Pool:      pool,
+		Collector: dbColl,
+		Cancel:    cancel,
+		Workers:   workers,
 		Status: &fleet.InstanceStatus{
 			Connected:    true,
 			DatabaseName: dbCfg.Database,
@@ -127,11 +141,15 @@ func connectAgentDBToFleet(
 		},
 	}
 	mgr.RegisterInstance(inst)
-
-	dbColl := collector.New(pool, cfg, detectPGVersion(pool),
-		logStructuredWrapper)
-	go dbColl.Run(instCtx)
+	startInstanceWorker(workers, func() { dbColl.Run(instCtx) })
 	logInfo("agentdb", "registered agent database %q in fleet", dbCfg.Name)
+}
+
+func agentDBRuntimeParent(_ context.Context) context.Context {
+	if shutdownCtx != nil {
+		return shutdownCtx
+	}
+	return context.Background()
 }
 
 func mapString(m map[string]any, key string) string {

--- a/sidecar/cmd/pg_sage_sidecar/fleet_runtime_audit_test.go
+++ b/sidecar/cmd/pg_sage_sidecar/fleet_runtime_audit_test.go
@@ -1,0 +1,437 @@
+package main
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/pg-sage/sidecar/internal/config"
+	"github.com/pg-sage/sidecar/internal/fleet"
+)
+
+func TestFleetRuntimeInitializesAnalyzeSemaphore(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured int
+		want       int
+	}{
+		{name: "zero uses safe default", configured: 0, want: 1},
+		{name: "negative uses safe default", configured: -1, want: 1},
+		{name: "configured fleet limit", configured: 3, want: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			preserveFleetRuntimeGlobals(t)
+			cfg = config.DefaultConfig()
+			cfg.Mode = "fleet"
+			cfg.Databases = nil
+			cfg.Tuner.MaxConcurrentAnalyze = tt.configured
+			analyzeSem = nil
+			fleetLLMBudget = nil
+			configController = nil
+
+			initFleetMultiDB()
+
+			if analyzeSem == nil {
+				t.Fatal("fleet bootstrap left the ANALYZE semaphore nil")
+			}
+			if got := cap(analyzeSem); got != tt.want {
+				t.Fatalf("ANALYZE semaphore capacity = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFleetOrchestratorRecordsHealthHistory(t *testing.T) {
+	fn := productionFunction(t, "main.go", "fleetDBOrchestrator")
+	if !callsSelectorWithPrefix(fn, "RecordHealth") {
+		t.Fatal("fleetDBOrchestrator never persists a health-history sample")
+	}
+
+	// Error propagation is deliberately not applicable here: one database's
+	// health-history write must not terminate another database's orchestrator.
+}
+
+func TestAgentDBCollectorHasProcessLifetimeAndLifecycleOwnership(t *testing.T) {
+	fn := productionFunction(t, "agentdb_fleet.go", "connectAgentDBToFleet")
+	withCancelArg := firstArgumentToSelectorCall(fn, "context", "WithCancel")
+	if withCancelArg == "" {
+		t.Fatal("AgentDB runtime does not create a cancellable instance context")
+	}
+	if withCancelArg == "ctx" {
+		t.Fatal("AgentDB collector inherits the 60-second reconcile context")
+	}
+	if !callsIdentifier(fn, "startInstanceWorker") {
+		t.Fatal("AgentDB collector is not tracked as an instance-owned worker")
+	}
+
+	fields := databaseInstanceFields(fn)
+	for _, required := range []string{"Collector", "Cancel", "Workers"} {
+		if !fields[required] {
+			t.Errorf("AgentDB instance does not publish lifecycle field %s", required)
+		}
+	}
+	if positionOfSelectorCall(fn, "RegisterInstance") <
+		positionOfIdentifier(fn, "dbColl") {
+		t.Error("AgentDB instance is registered before its collector is built")
+	}
+
+	// Invalid deployment shapes are covered by TestEligibleForFleet_Rejections.
+	// No state-transition test is needed here: removal/drain behavior belongs to
+	// fleet manager lifecycle tests; this test verifies the missing ownership link.
+}
+
+func TestAgentDBCollectorRejectsCanceledRegistration(t *testing.T) {
+	manager := fleet.NewManager(config.DefaultConfig())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	connectAgentDBToFleet(ctx, manager, config.DatabaseConfig{
+		Name: "agentdb:late", Host: "127.0.0.1", Database: "late",
+	})
+
+	if got := manager.InstanceCount(); got != 0 {
+		t.Fatalf("canceled reconcile registered %d AgentDB instances, want 0", got)
+	}
+}
+
+func TestMetaDBBootstrapBuildsGeneralLLMRuntime(t *testing.T) {
+	fn := productionFunction(t, "metadb.go", "initMetaDBFleet")
+	assignments := assignedPackageCalls(fn)
+	if assignments["llmClient"] != "llm.New" {
+		t.Error("meta-db bootstrap does not construct the general LLM client")
+	}
+	if assignments["llmMgr"] != "llm.NewManager" {
+		t.Error("meta-db bootstrap does not construct the LLM manager")
+	}
+
+	// Provider failures and malformed LLM responses are tested by internal/llm;
+	// this regression is specifically the missing meta-mode state transition.
+}
+
+func TestFleetLLMBudgetScopesEveryConsumer(t *testing.T) {
+	fn := productionFunction(t, "main.go", "buildFleetLLMFeatures")
+	if !callsSelector(fn, "SetBudget") {
+		t.Fatal("fleet LLM feature builder never attaches the per-database budget")
+	}
+	if !callsPackageSelector(fn, "llm", "NewManager") {
+		t.Error("advisor and tuner do not receive a database-scoped LLM manager")
+	}
+	assertCallOmitsGlobal(t, fn, "advisor", "New", "llmMgr")
+	assertCallOmitsGlobal(t, fn, "briefing", "New", "llmClient")
+	assertMethodReceiverOmitsGlobal(t, fn, "ForPurpose", "llmMgr")
+
+	fleetInit := productionFunction(t, "main.go", "initFleetMultiDB")
+	assertMethodArgumentOmitsGlobal(t, fleetInit, "WithLLM", "llmClient")
+
+	metaRuntime := productionFunction(t, "metadb.go", "buildStoreDatabaseRuntime")
+	if !callsSelector(metaRuntime, "WithLLM") {
+		t.Error("meta-db RCA engine is not wired to a database-scoped LLM client")
+	} else {
+		assertMethodArgumentOmitsGlobal(t, metaRuntime, "WithLLM", "llmClient")
+	}
+}
+
+func preserveFleetRuntimeGlobals(t *testing.T) {
+	t.Helper()
+	oldCfg := cfg
+	oldManager := fleetMgr
+	oldClient := llmClient
+	oldLLMManager := llmMgr
+	oldSemaphore := analyzeSem
+	oldBudget := fleetLLMBudget
+	oldController := configController
+	t.Cleanup(func() {
+		cfg = oldCfg
+		fleetMgr = oldManager
+		llmClient = oldClient
+		llmMgr = oldLLMManager
+		analyzeSem = oldSemaphore
+		fleetLLMBudget = oldBudget
+		configController = oldController
+	})
+}
+
+func productionFunction(t *testing.T, file, name string) *ast.FuncDecl {
+	t.Helper()
+	_, current, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source directory")
+	}
+	path := filepath.Join(filepath.Dir(current), file)
+	source, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	parsed, err := parser.ParseFile(token.NewFileSet(), path, source, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	for _, declaration := range parsed.Decls {
+		fn, ok := declaration.(*ast.FuncDecl)
+		if ok && fn.Name.Name == name {
+			return fn
+		}
+	}
+	t.Fatalf("function %s not found in %s", name, path)
+	return nil
+}
+
+func callsSelector(fn *ast.FuncDecl, selector string) bool {
+	found := false
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if ok && selectorName(call.Fun) == selector {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+func callsSelectorWithPrefix(fn *ast.FuncDecl, prefix string) bool {
+	found := false
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if ok && strings.HasPrefix(selectorName(call.Fun), prefix) {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+func callsPackageSelector(fn *ast.FuncDecl, pkg, selector string) bool {
+	found := false
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if ok && packageSelector(call.Fun) == pkg+"."+selector {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+func callsIdentifier(fn *ast.FuncDecl, name string) bool {
+	found := false
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		ident, isIdent := callFun(call).(*ast.Ident)
+		if ok && isIdent && ident.Name == name {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+func callFun(call *ast.CallExpr) ast.Expr {
+	if call == nil {
+		return nil
+	}
+	return call.Fun
+}
+
+func selectorName(expr ast.Expr) string {
+	selector, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	return selector.Sel.Name
+}
+
+func packageSelector(expr ast.Expr) string {
+	selector, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	return pkg.Name + "." + selector.Sel.Name
+}
+
+func firstArgumentToSelectorCall(
+	fn *ast.FuncDecl, pkg, selector string,
+) string {
+	argument := ""
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || packageSelector(call.Fun) != pkg+"."+selector ||
+			len(call.Args) == 0 {
+			return true
+		}
+		argument = expressionIdentifier(call.Args[0])
+		return false
+	})
+	return argument
+}
+
+func expressionIdentifier(expr ast.Expr) string {
+	ident, ok := expr.(*ast.Ident)
+	if ok {
+		return ident.Name
+	}
+	return "non-identifier"
+}
+
+func databaseInstanceFields(fn *ast.FuncDecl) map[string]bool {
+	fields := make(map[string]bool)
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		literal, ok := node.(*ast.CompositeLit)
+		selector, isSelector := literalType(literal).(*ast.SelectorExpr)
+		if !ok || !isSelector || selector.Sel.Name != "DatabaseInstance" {
+			return true
+		}
+		for _, element := range literal.Elts {
+			item, isItem := element.(*ast.KeyValueExpr)
+			key, isKey := itemKey(item).(*ast.Ident)
+			if isItem && isKey {
+				fields[key.Name] = true
+			}
+		}
+		return false
+	})
+	return fields
+}
+
+func literalType(literal *ast.CompositeLit) ast.Expr {
+	if literal == nil {
+		return nil
+	}
+	return literal.Type
+}
+
+func itemKey(item *ast.KeyValueExpr) ast.Expr {
+	if item == nil {
+		return nil
+	}
+	return item.Key
+}
+
+func positionOfSelectorCall(fn *ast.FuncDecl, selector string) token.Pos {
+	position := token.NoPos
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if position == token.NoPos && ok &&
+			selectorName(call.Fun) == selector {
+			position = call.Pos()
+			return false
+		}
+		return true
+	})
+	return position
+}
+
+func positionOfIdentifier(fn *ast.FuncDecl, name string) token.Pos {
+	position := token.NoPos
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		ident, ok := node.(*ast.Ident)
+		if position == token.NoPos && ok && ident.Name == name {
+			position = ident.Pos()
+			return false
+		}
+		return true
+	})
+	return position
+}
+
+func assignedPackageCalls(fn *ast.FuncDecl) map[string]string {
+	assignments := make(map[string]string)
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		assignment, ok := node.(*ast.AssignStmt)
+		if !ok || len(assignment.Lhs) != 1 || len(assignment.Rhs) != 1 {
+			return true
+		}
+		lhs, lhsOK := assignment.Lhs[0].(*ast.Ident)
+		call, callOK := assignment.Rhs[0].(*ast.CallExpr)
+		if lhsOK && callOK {
+			assignments[lhs.Name] = packageSelector(call.Fun)
+		}
+		return true
+	})
+	return assignments
+}
+
+func assertCallOmitsGlobal(
+	t *testing.T,
+	fn *ast.FuncDecl,
+	pkg, selector, forbidden string,
+) {
+	t.Helper()
+	for _, call := range packageCalls(fn, pkg, selector) {
+		if expressionContainsIdentifier(call, forbidden) {
+			t.Errorf("%s.%s still receives shared global %s", pkg, selector, forbidden)
+		}
+	}
+}
+
+func assertMethodReceiverOmitsGlobal(
+	t *testing.T, fn *ast.FuncDecl, method, forbidden string,
+) {
+	t.Helper()
+	for _, call := range selectorCalls(fn, method) {
+		selector := call.Fun.(*ast.SelectorExpr)
+		if expressionContainsIdentifier(selector.X, forbidden) {
+			t.Errorf("%s is still called on shared global %s", method, forbidden)
+		}
+	}
+}
+
+func assertMethodArgumentOmitsGlobal(
+	t *testing.T, fn *ast.FuncDecl, method, forbidden string,
+) {
+	t.Helper()
+	for _, call := range selectorCalls(fn, method) {
+		for _, argument := range call.Args {
+			if expressionContainsIdentifier(argument, forbidden) {
+				t.Errorf("%s still receives shared global %s", method, forbidden)
+			}
+		}
+	}
+}
+
+func packageCalls(fn *ast.FuncDecl, pkg, selector string) []*ast.CallExpr {
+	var calls []*ast.CallExpr
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if ok && packageSelector(call.Fun) == pkg+"."+selector {
+			calls = append(calls, call)
+		}
+		return true
+	})
+	return calls
+}
+
+func selectorCalls(fn *ast.FuncDecl, selector string) []*ast.CallExpr {
+	var calls []*ast.CallExpr
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if ok && selectorName(call.Fun) == selector {
+			calls = append(calls, call)
+		}
+		return true
+	})
+	return calls
+}
+
+func expressionContainsIdentifier(node ast.Node, name string) bool {
+	found := false
+	ast.Inspect(node, func(child ast.Node) bool {
+		ident, ok := child.(*ast.Ident)
+		if ok && ident.Name == name {
+			found = true
+		}
+		return !found
+	})
+	return found
+}

--- a/sidecar/cmd/pg_sage_sidecar/fleet_runtime_helpers.go
+++ b/sidecar/cmd/pg_sage_sidecar/fleet_runtime_helpers.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/pg-sage/sidecar/internal/advisor"
+	"github.com/pg-sage/sidecar/internal/analyzer"
+	"github.com/pg-sage/sidecar/internal/collector"
+	"github.com/pg-sage/sidecar/internal/fleet"
+	"github.com/pg-sage/sidecar/internal/llm"
+	"github.com/pg-sage/sidecar/internal/optimizer"
+	"github.com/pg-sage/sidecar/internal/tuner"
+)
+
+func initializeAnalyzeSemaphore() {
+	maxAnalyze := cfg.Tuner.MaxConcurrentAnalyze
+	if maxAnalyze <= 0 {
+		maxAnalyze = 1
+	}
+	analyzeSem = make(chan struct{}, maxAnalyze)
+	logInfo("startup", "ANALYZE semaphore sized to %d concurrent slots",
+		maxAnalyze)
+}
+
+func newFleetOptimizerClient(
+	databaseName string, general *llm.Client,
+) *llm.Client {
+	if !cfg.LLM.OptimizerLLM.Enabled {
+		return general
+	}
+	client := llm.NewOptimizerClient(
+		&cfg.LLM, &cfg.LLM.OptimizerLLM, logStructuredWrapper,
+	)
+	if fleetLLMBudget != nil {
+		client.SetBudget(dbBudget{b: fleetLLMBudget, db: databaseName})
+	}
+	return client
+}
+
+func newFleetOptimizer(
+	pool *pgxpool.Pool,
+	pgVersion int,
+	general, optimizerClient *llm.Client,
+) *optimizer.Optimizer {
+	if !cfg.LLM.Optimizer.Enabled {
+		return nil
+	}
+	var fallback *llm.Client
+	if cfg.LLM.OptimizerLLM.FallbackToGeneral &&
+		optimizerClient != general {
+		fallback = general
+	}
+	return optimizer.New(
+		optimizerClient, fallback, pool, &cfg.LLM.Optimizer,
+		pgVersion, false, cfg.LLM.OptimizerLLM.MaxOutputTokens,
+		logStructuredWrapper,
+	)
+}
+
+func newFleetAdvisor(
+	pool *pgxpool.Pool,
+	coll *collector.Collector,
+	databaseName string,
+	manager *llm.Manager,
+) analyzer.ConfigAdvisor {
+	if !cfg.Advisor.Enabled {
+		return nil
+	}
+	result := advisor.New(pool, cfg, coll, manager, logStructuredWrapper)
+	result.WithCloudEnv(detectCloudEnv(pool))
+	result.WithDatabaseName(databaseName)
+	return result
+}
+
+func newFleetTuner(
+	pool *pgxpool.Pool, manager *llm.Manager,
+) *tuner.Tuner {
+	if !cfg.Tuner.Enabled {
+		return nil
+	}
+	hintPlan, _ := tuner.DetectHintPlan(context.Background(), pool)
+	options := fleetTunerOptions(manager)
+	return tuner.New(
+		pool, fleetTunerConfig(), hintPlan,
+		logStructuredWrapper, options...,
+	)
+}
+
+func fleetTunerOptions(manager *llm.Manager) []tuner.Option {
+	if !cfg.Tuner.LLMEnabled || manager == nil {
+		return nil
+	}
+	primary := manager.ForPurpose("query_tuning")
+	var fallback *llm.Client
+	if cfg.LLM.OptimizerLLM.FallbackToGeneral {
+		fallback = manager.General
+	}
+	return []tuner.Option{tuner.WithLLM(primary, fallback)}
+}
+
+func fleetTunerConfig() tuner.TunerConfig {
+	return tuner.TunerConfig{
+		Enabled:                       cfg.Tuner.Enabled,
+		LLMEnabled:                    cfg.Tuner.LLMEnabled,
+		WorkMemMaxMB:                  cfg.Tuner.WorkMemMaxMB,
+		PlanTimeRatio:                 cfg.Tuner.PlanTimeRatio,
+		NestedLoopRowThreshold:        cfg.Tuner.NestedLoopRowThreshold,
+		ParallelMinTableRows:          cfg.Tuner.ParallelMinTableRows,
+		MinQueryCalls:                 cfg.Tuner.MinQueryCalls,
+		VerifyAfterApply:              cfg.Tuner.VerifyAfterApply,
+		CascadeCooldownCycles:         cfg.Trust.CascadeCooldownCycles,
+		HintRetirementDays:            cfg.Tuner.HintRetirementDays,
+		RevalidationIntervalHours:     cfg.Tuner.RevalidationIntervalHours,
+		RevalidationKeepRatio:         cfg.Tuner.RevalidationKeepRatio,
+		RevalidationRollbackRatio:     cfg.Tuner.RevalidationRollbackRatio,
+		RevalidationExplainTimeoutMs:  cfg.Tuner.RevalidationExplainTimeoutMs,
+		StaleStatsEstimateSkew:        cfg.Tuner.StaleStatsEstimateSkew,
+		StaleStatsModRatio:            cfg.Tuner.StaleStatsModRatio,
+		StaleStatsAgeMinutes:          cfg.Tuner.StaleStatsAgeMinutes,
+		AnalyzeMaxTableMB:             cfg.Tuner.AnalyzeMaxTableMB,
+		AnalyzeCooldownMinutes:        cfg.Tuner.AnalyzeCooldownMinutes,
+		AnalyzeMaintenanceThresholdMB: cfg.Tuner.AnalyzeMaintenanceThresholdMB,
+		AnalyzeTimeoutMs:              cfg.Tuner.AnalyzeTimeoutMs,
+		MaxConcurrentAnalyze:          cfg.Tuner.MaxConcurrentAnalyze,
+	}
+}
+
+func initializeFleetBudget(databaseNames []string) {
+	fleetLLMBudget = nil
+	if cfg.LLM.FleetTokenBudgetDaily <= 0 {
+		return
+	}
+	fleetLLMBudget = fleet.NewBudget(
+		cfg.LLM.FleetTokenBudgetDaily, databaseNames,
+	)
+	go resetFleetBudgetDaily(shutdownCtx, fleetLLMBudget)
+	logInfo("fleet", "per-database LLM budget enabled: "+
+		"%d tokens/day across %d databases",
+		cfg.LLM.FleetTokenBudgetDaily, len(databaseNames))
+}

--- a/sidecar/cmd/pg_sage_sidecar/main.go
+++ b/sidecar/cmd/pg_sage_sidecar/main.go
@@ -523,14 +523,7 @@ func initStandalone() {
 
 	// 3c. Fleet-wide ANALYZE semaphore — bounds parallel
 	// ANALYZE execution across every Executor instance.
-	maxAnalyze := cfg.Tuner.MaxConcurrentAnalyze
-	if maxAnalyze <= 0 {
-		maxAnalyze = 1
-	}
-	analyzeSem = make(chan struct{}, maxAnalyze)
-	logInfo("startup",
-		"ANALYZE semaphore sized to %d concurrent slots",
-		maxAnalyze)
+	initializeAnalyzeSemaphore()
 
 	// 4. Verify grants.
 	executor.VerifyGrants(ctx, pool, cfg.Postgres.User, logStructuredWrapper)
@@ -1145,6 +1138,7 @@ func startInstanceWorker(workers *sync.WaitGroup, run func()) {
 // and executors for each database in fleet config.
 func initFleetMultiDB() {
 	fleetMgr = fleet.NewManager(cfg)
+	initializeAnalyzeSemaphore()
 
 	// LLM client + manager (shared across fleet).
 	llmClient = llm.New(&cfg.LLM, logStructuredWrapper)
@@ -1153,16 +1147,11 @@ func initFleetMultiDB() {
 
 	// Per-database LLM token budget (F5): split a fleet-wide daily cap
 	// across databases so one noisy DB can't drain the whole budget.
-	if cfg.LLM.FleetTokenBudgetDaily > 0 {
-		names := make([]string, 0, len(cfg.Databases))
-		for _, d := range cfg.Databases {
-			names = append(names, d.Name)
-		}
-		fleetLLMBudget = fleet.NewBudget(cfg.LLM.FleetTokenBudgetDaily, names)
-		go resetFleetBudgetDaily(shutdownCtx, fleetLLMBudget)
-		logInfo("fleet", "per-database LLM budget enabled: %d tokens/day across %d databases",
-			cfg.LLM.FleetTokenBudgetDaily, len(names))
+	names := make([]string, 0, len(cfg.Databases))
+	for _, database := range cfg.Databases {
+		names = append(names, database.Name)
 	}
+	initializeFleetBudget(names)
 
 	var configPool *pgxpool.Pool // first connected DB used for config store
 	adminBootstrapped := false   // admin is created on the first connected DB
@@ -1329,20 +1318,25 @@ func initFleetMultiDB() {
 			fcIface = fc
 		}
 
+		// Every LLM consumer for this database shares the same scoped budget.
+		dbLLMClient := llm.New(&cfg.LLM, logStructuredWrapper)
+		if fleetLLMBudget != nil {
+			dbLLMClient.SetBudget(dbBudget{b: fleetLLMBudget, db: name})
+		}
+		dbOptimizerClient := newFleetOptimizerClient(name, dbLLMClient)
+		dbLLMManager := llm.NewManager(
+			dbLLMClient, dbOptimizerClient,
+			cfg.LLM.OptimizerLLM.FallbackToGeneral,
+		)
+
 		// Per-database optimizer.
 		var dbOpt *optimizer.Optimizer
 		if cfg.LLM.Optimizer.Enabled && llmClient.IsEnabled() {
-			optClient := llmClient
-			if cfg.LLM.OptimizerLLM.Enabled {
-				optClient = llm.NewOptimizerClient(
-					&cfg.LLM, &cfg.LLM.OptimizerLLM,
-					logStructuredWrapper,
-				)
-			}
+			optClient := dbOptimizerClient
 			var fallback *llm.Client
 			if cfg.LLM.OptimizerLLM.FallbackToGeneral &&
-				optClient != llmClient {
-				fallback = llmClient
+				optClient != dbLLMClient {
+				fallback = dbLLMClient
 			}
 			dbOpt = optimizer.New(
 				optClient, fallback, dbPool,
@@ -1361,7 +1355,7 @@ func initFleetMultiDB() {
 		var dbAdvIface analyzer.ConfigAdvisor
 		if cfg.Advisor.Enabled && llmClient.IsEnabled() {
 			dbAdv := advisor.New(
-				dbPool, cfg, dbColl, llmMgr,
+				dbPool, cfg, dbColl, dbLLMManager,
 				logStructuredWrapper,
 			)
 			dbAdv.WithCloudEnv(dbCloudEnv)
@@ -1403,12 +1397,12 @@ func initFleetMultiDB() {
 				MaxConcurrentAnalyze:          cfg.Tuner.MaxConcurrentAnalyze,
 			}
 			var tunerOpts []tuner.Option
-			if cfg.Tuner.LLMEnabled && llmMgr != nil {
-				tc := llmMgr.ForPurpose("query_tuning")
+			if cfg.Tuner.LLMEnabled && dbLLMManager != nil {
+				tc := dbLLMManager.ForPurpose("query_tuning")
 				var fb *llm.Client
 				if cfg.LLM.OptimizerLLM.FallbackToGeneral &&
-					llmMgr.General != nil {
-					fb = llmMgr.General
+					dbLLMManager.General != nil {
+					fb = dbLLMManager.General
 				}
 				tunerOpts = append(tunerOpts,
 					tuner.WithLLM(tc, fb))
@@ -1455,7 +1449,7 @@ func initFleetMultiDB() {
 		var dbBrief *briefing.Worker
 		if llmClient.IsEnabled() {
 			dbBrief = briefing.New(
-				dbPool, cfg, llmClient,
+				dbPool, cfg, dbLLMClient,
 				logStructuredWrapper,
 			)
 		}
@@ -1484,7 +1478,7 @@ func initFleetMultiDB() {
 			dbRCAEng = rca.NewEngine(
 				&cfg.RCA, logStructuredWrapper)
 			if llmClient.IsEnabled() {
-				dbRCAEng.WithLLM(llmClient)
+				dbRCAEng.WithLLM(dbLLMClient)
 			}
 			// v0.9.1: fleet-mode logwatch via per-cluster fanout.
 			if dbLogFanout != nil {
@@ -1533,13 +1527,14 @@ func initFleetMultiDB() {
 		dbExec.WithDispatcher(dbDispatcher)
 		dbExec.WithDatabaseName(name)
 		if llmClient != nil && llmClient.IsEnabled() {
-			dbExec.WithJustifier(llmClient)
+			dbExec.WithJustifier(dbLLMClient)
 		}
 		dbAnal.WithDispatcher(dbDispatcher)
 		dbAnal.WithDatabaseName(name)
 		if llmClient != nil && llmClient.IsEnabled() {
-			dbAnal.WithPlanNarrator(
-				analyzer.NewLLMPlanNarrator(llmClient, logStructuredWrapper))
+			dbAnal.WithPlanNarrator(analyzer.NewLLMPlanNarrator(
+				dbLLMClient, logStructuredWrapper,
+			))
 		}
 
 		startInstanceWorker(instWorkers, func() {
@@ -1555,7 +1550,7 @@ func initFleetMultiDB() {
 				logStructuredWrapper,
 			)
 			if llmClient != nil && llmClient.IsEnabled() {
-				dbLint.SetLLMClient(llmClient)
+				dbLint.SetLLMClient(dbLLMClient)
 			}
 			startInstanceWorker(instWorkers, func() { dbLint.Run(instCtx) })
 		}
@@ -1563,8 +1558,8 @@ func initFleetMultiDB() {
 		// Per-database migration DDL safety advisor.
 		if cfg.Migration.Enabled {
 			var dbMigLLM *llm.Client
-			if llmMgr != nil {
-				dbMigLLM = llmMgr.General
+			if dbLLMManager != nil {
+				dbMigLLM = dbLLMManager.General
 			}
 			dbAdvisor := migration.NewAdvisor(
 				dbPool, &cfg.Migration,
@@ -1848,6 +1843,7 @@ func fleetDBOrchestrator(
 			// Update fleet status for this instance.
 			if inst := fleetMgr.GetInstance(name); inst != nil {
 				updateInstanceFindings(ctx, inst)
+				fleetMgr.RecordHealthSnapshot(ctx, name)
 			}
 		case <-ctx.Done():
 			return
@@ -1867,108 +1863,38 @@ func buildFleetLLMFeatures(
 	analyzer.ConfigAdvisor,
 	*tuner.Tuner,
 	*briefing.Worker,
+	*llm.Client,
+	*llm.Manager,
 ) {
 	if llmClient == nil || !llmClient.IsEnabled() {
-		return nil, nil, nil, nil
+		return nil, nil, nil, nil, nil, nil
 	}
-
-	// Optimizer.
-	var dbOpt *optimizer.Optimizer
-	if cfg.LLM.Optimizer.Enabled {
-		optClient := llmClient
-		if cfg.LLM.OptimizerLLM.Enabled {
-			optClient = llm.NewOptimizerClient(
-				&cfg.LLM, &cfg.LLM.OptimizerLLM,
-				logStructuredWrapper,
-			)
-		} else if fleetLLMBudget != nil {
-			// Per-DB client so the fleet budget attaches per database
-			// instead of to the shared client (F5).
-			optClient = llm.New(&cfg.LLM, logStructuredWrapper)
-		}
-		if fleetLLMBudget != nil {
-			optClient.SetBudget(dbBudget{b: fleetLLMBudget, db: databaseName})
-		}
-		var fallback *llm.Client
-		if cfg.LLM.OptimizerLLM.FallbackToGeneral &&
-			optClient != llmClient {
-			fallback = llmClient
-		}
-		dbOpt = optimizer.New(
-			optClient, fallback, dbPool,
-			&cfg.LLM.Optimizer, dbPGVersion, false,
-			cfg.LLM.OptimizerLLM.MaxOutputTokens,
-			logStructuredWrapper,
-		)
+	dbClient := llm.New(&cfg.LLM, logStructuredWrapper)
+	if fleetLLMBudget != nil {
+		dbClient.SetBudget(dbBudget{b: fleetLLMBudget, db: databaseName})
 	}
+	managerOptimizer := newFleetOptimizerClient(databaseName, dbClient)
+	dbLLMMgr := llm.NewManager(
+		dbClient, managerOptimizer,
+		cfg.LLM.OptimizerLLM.FallbackToGeneral,
+	)
 
-	// Advisor (with per-database cloud detection).
-	var dbAdvIface analyzer.ConfigAdvisor
-	if cfg.Advisor.Enabled {
-		dbAdv := advisor.New(
-			dbPool, cfg, dbColl, llmMgr,
-			logStructuredWrapper,
-		)
-		dbCloudEnv := detectCloudEnv(dbPool)
-		dbAdv.WithCloudEnv(dbCloudEnv)
-		dbAdv.WithDatabaseName(databaseName)
-		dbAdvIface = dbAdv
-	}
+	dbOpt := newFleetOptimizer(
+		dbPool, dbPGVersion, dbClient, managerOptimizer,
+	)
 
-	// Tuner.
-	var dbTuner *tuner.Tuner
-	if cfg.Tuner.Enabled {
-		hpAvail, _ := tuner.DetectHintPlan(
-			context.Background(), dbPool)
-		tunerCfg := tuner.TunerConfig{
-			Enabled:                cfg.Tuner.Enabled,
-			LLMEnabled:             cfg.Tuner.LLMEnabled,
-			WorkMemMaxMB:           cfg.Tuner.WorkMemMaxMB,
-			PlanTimeRatio:          cfg.Tuner.PlanTimeRatio,
-			NestedLoopRowThreshold: cfg.Tuner.NestedLoopRowThreshold,
-			ParallelMinTableRows:   cfg.Tuner.ParallelMinTableRows,
-			MinQueryCalls:          cfg.Tuner.MinQueryCalls,
-			VerifyAfterApply:       cfg.Tuner.VerifyAfterApply,
-			CascadeCooldownCycles:  cfg.Trust.CascadeCooldownCycles,
+	dbAdvIface := newFleetAdvisor(
+		dbPool, dbColl, databaseName, dbLLMMgr,
+	)
 
-			// v0.8.5 Feature 1 — Hint revalidation loop.
-			HintRetirementDays:           cfg.Tuner.HintRetirementDays,
-			RevalidationIntervalHours:    cfg.Tuner.RevalidationIntervalHours,
-			RevalidationKeepRatio:        cfg.Tuner.RevalidationKeepRatio,
-			RevalidationRollbackRatio:    cfg.Tuner.RevalidationRollbackRatio,
-			RevalidationExplainTimeoutMs: cfg.Tuner.RevalidationExplainTimeoutMs,
-
-			// v0.8.5 Feature 2 — Stale-stats detection + ANALYZE.
-			StaleStatsEstimateSkew:        cfg.Tuner.StaleStatsEstimateSkew,
-			StaleStatsModRatio:            cfg.Tuner.StaleStatsModRatio,
-			StaleStatsAgeMinutes:          cfg.Tuner.StaleStatsAgeMinutes,
-			AnalyzeMaxTableMB:             cfg.Tuner.AnalyzeMaxTableMB,
-			AnalyzeCooldownMinutes:        cfg.Tuner.AnalyzeCooldownMinutes,
-			AnalyzeMaintenanceThresholdMB: cfg.Tuner.AnalyzeMaintenanceThresholdMB,
-			AnalyzeTimeoutMs:              cfg.Tuner.AnalyzeTimeoutMs,
-			MaxConcurrentAnalyze:          cfg.Tuner.MaxConcurrentAnalyze,
-		}
-		var tunerOpts []tuner.Option
-		if cfg.Tuner.LLMEnabled && llmMgr != nil {
-			tc := llmMgr.ForPurpose("query_tuning")
-			var fb *llm.Client
-			if cfg.LLM.OptimizerLLM.FallbackToGeneral &&
-				llmMgr.General != nil {
-				fb = llmMgr.General
-			}
-			tunerOpts = append(tunerOpts,
-				tuner.WithLLM(tc, fb))
-		}
-		dbTuner = tuner.New(dbPool, tunerCfg, hpAvail,
-			logStructuredWrapper, tunerOpts...)
-	}
+	dbTuner := newFleetTuner(dbPool, dbLLMMgr)
 
 	// Briefing.
 	dbBrief := briefing.New(
-		dbPool, cfg, llmClient, logStructuredWrapper,
+		dbPool, cfg, dbClient, logStructuredWrapper,
 	)
 
-	return dbOpt, dbAdvIface, dbTuner, dbBrief
+	return dbOpt, dbAdvIface, dbTuner, dbBrief, dbClient, dbLLMMgr
 }
 
 func resolveDBName() string {

--- a/sidecar/cmd/pg_sage_sidecar/metadb.go
+++ b/sidecar/cmd/pg_sage_sidecar/metadb.go
@@ -19,6 +19,8 @@ import (
 	"github.com/pg-sage/sidecar/internal/crypto"
 	"github.com/pg-sage/sidecar/internal/executor"
 	"github.com/pg-sage/sidecar/internal/fleet"
+	"github.com/pg-sage/sidecar/internal/llm"
+	"github.com/pg-sage/sidecar/internal/rca"
 	"github.com/pg-sage/sidecar/internal/schema"
 	"github.com/pg-sage/sidecar/internal/store"
 )
@@ -313,6 +315,10 @@ func logRetry(
 // Starts a background goroutine to reconnect failed databases.
 func initMetaDBFleet(state *metaDBState) {
 	fleetMgr = fleet.NewManager(cfg)
+	initializeAnalyzeSemaphore()
+	llmClient = llm.New(&cfg.LLM, logStructuredWrapper)
+	registerLLMConfigOwner()
+	llmMgr = llm.NewManager(llmClient, nil, false)
 
 	ctx, cancel := context.WithTimeout(
 		context.Background(), metaDBTimeout,
@@ -326,6 +332,11 @@ func initMetaDBFleet(state *metaDBState) {
 	}
 
 	logInfo("meta-db", "found %d enabled databases", len(records))
+	names := make([]string, 0, len(records))
+	for _, record := range records {
+		names = append(names, record.Name)
+	}
+	initializeFleetBudget(names)
 	for _, rec := range records {
 		registerStoreDatabase(state, rec)
 	}
@@ -414,9 +425,9 @@ func buildStoreDatabaseRuntime(
 	startInstanceWorker(instWorkers, func() { dbColl.Run(instCtx) })
 
 	// LLM features for meta-db registered databases.
-	dbOpt, dbAdvIface, dbTuner, dbBrief :=
+	dbOpt, dbAdvIface, dbTuner, dbBrief, dbLLMClient, _ :=
 		buildFleetLLMFeatures(dbPool, dbPGVersion, dbColl,
-			rec.DatabaseName)
+			rec.Name)
 
 	// dbTuner is a *tuner.Tuner which may be nil when cfg.Tuner.Enabled
 	// is false. Passing the typed nil directly produces a non-nil
@@ -433,10 +444,29 @@ func buildStoreDatabaseRuntime(
 	dbAnal.WithSupplementalDetector(executor.NewRunawayDetector(
 		dbPool, &cfg.Runaway, logStructuredWrapper,
 	))
+	var dbRCAEng *rca.Engine
+	if cfg.RCA.Enabled {
+		dbRCAEng = rca.NewEngine(&cfg.RCA, logStructuredWrapper)
+		if dbLLMClient != nil {
+			dbRCAEng.WithLLM(dbLLMClient)
+		}
+		dbAnal.WithRCAEngine(&rcaAdapter{e: dbRCAEng})
+	}
+	if dbLLMClient != nil {
+		dbAnal.WithPlanNarrator(analyzer.NewLLMPlanNarrator(
+			dbLLMClient, logStructuredWrapper,
+		))
+	}
 	startInstanceWorker(instWorkers, func() { dbAnal.Run(instCtx) })
 
 	dbExec := buildExecutor(rec, dbPool, dbAnal, dbCloudEnv)
 	dbActionStore := store.NewActionStore(dbPool)
+	if dbLLMClient != nil {
+		dbExec.WithJustifier(dbLLMClient)
+	}
+	if dbRCAEng != nil {
+		dbRCAEng.WithActionStore(dbActionStore)
+	}
 	startInstanceWorker(instWorkers, func() {
 		store.StartActionExpiry(
 			instCtx, dbActionStore, logStructuredWrapper)
@@ -615,6 +645,7 @@ func buildExecutor(
 	dbExec := executor.New(
 		dbPool, dbExecCfg, dbAnal, rStart, logStructuredWrapper,
 	)
+	dbExec.WithAnalyzeSemaphore(analyzeSem)
 	dbActionStore := store.NewActionStore(dbPool)
 	dbExec.WithActionStore(dbActionStore, resolveExecMode(rec))
 	if err := dbExec.SetTrustLevel(rec.TrustLevel); err != nil {

--- a/sidecar/internal/api/audit_llm_models_security_test.go
+++ b/sidecar/internal/api/audit_llm_models_security_test.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/pg-sage/sidecar/internal/config"
+)
+
+func auditLLMModelsRouter(cfg *config.Config) http.Handler {
+	mux := http.NewServeMux()
+	registerAPIRoutes(mux, nil, cfg, nil, nil, nil, false)
+	return mux
+}
+
+func auditModelsRequest(
+	t *testing.T,
+	handler http.Handler,
+	userRole string,
+	body string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/llm/models",
+		strings.NewReader(body),
+	)
+	if userRole != "" {
+		user := testViewerUser()
+		user.Role = userRole
+		req = withUser(req, user)
+	}
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+	return recorder
+}
+
+func TestAuditLLMModelDiscoveryRequiresAdmin(t *testing.T) {
+	// Invalid JSON is deliberate: authorization must run before body parsing
+	// or any provider request, so unauthorized callers cannot probe behavior.
+	handler := auditLLMModelsRouter(&config.Config{})
+	tests := []struct {
+		name string
+		role string
+		want int
+	}{
+		{name: "anonymous", role: "", want: http.StatusUnauthorized},
+		{name: "viewer", role: "viewer", want: http.StatusForbidden},
+		{name: "operator", role: "operator", want: http.StatusForbidden},
+		{name: "admin reaches handler", role: "admin", want: http.StatusBadRequest},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := auditModelsRequest(t, handler, test.role, `{`)
+			if response.Code != test.want {
+				t.Fatalf("status = %d, want %d; body=%s",
+					response.Code, test.want, response.Body.String())
+			}
+		})
+	}
+}
+
+func TestAuditLLMModelDiscoveryRejectsPrivateEndpointOverride(t *testing.T) {
+	var privateRequests atomic.Int32
+	privateServer := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			privateRequests.Add(1)
+			_, _ = w.Write([]byte(`{"data":[{"id":"stolen"}]}`))
+		},
+	))
+	defer privateServer.Close()
+
+	cfg := &config.Config{}
+	cfg.LLM.Endpoint = "https://api.openai.com/v1"
+	cfg.LLM.APIKey = "configured-secret"
+	handler := auditLLMModelsRouter(cfg)
+	body := `{"config":{"llm.endpoint":"` + privateServer.URL + `"}}`
+	response := auditModelsRequest(t, handler, "admin", body)
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("private override status = %d, want 400; body=%s",
+			response.Code, response.Body.String())
+	}
+	if got := privateRequests.Load(); got != 0 {
+		t.Fatalf("private endpoint received %d requests, want 0", got)
+	}
+}
+
+func TestAuditLLMModelDiscoveryRejectsDangerousEndpointForms(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+	}{
+		{name: "cloud metadata", endpoint: "http://169.254.169.254/latest"},
+		{name: "ipv6 loopback", endpoint: "http://[::1]:8080/v1"},
+		{name: "integer loopback", endpoint: "http://2130706433/v1"},
+		{name: "unsupported file scheme", endpoint: "file:///etc/passwd"},
+		{name: "credential smuggling", endpoint: "https://user:pass@example.com/v1"},
+		{name: "empty host", endpoint: "https:///v1"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := validateLLMDiscoveryEndpoint(
+				t.Context(), test.endpoint,
+			); err == nil {
+				t.Fatalf("dangerous endpoint %q was accepted", test.endpoint)
+			}
+		})
+	}
+}
+
+func TestAuditLLMModelDiscoveryFailsClosedOnDNSFailure(t *testing.T) {
+	err := validateLLMDiscoveryEndpoint(
+		t.Context(), "https://does-not-exist.invalid/v1",
+	)
+	if err == nil {
+		t.Fatal("unresolvable endpoint was accepted")
+	}
+}
+
+func TestAuditEndpointOverrideCannotReuseConfiguredCredential(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.LLM.Endpoint = "https://api.openai.com/v1"
+	cfg.LLM.APIKey = "configured-secret"
+	handler := auditLLMModelsRouter(cfg)
+	body := `{"config":{"llm.endpoint":"https://example.com/v1"}}`
+	response := auditModelsRequest(t, handler, "admin", body)
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("credential reuse status = %d, want 400; body=%s",
+			response.Code, response.Body.String())
+	}
+	if !strings.Contains(strings.ToLower(response.Body.String()), "api key") {
+		t.Fatalf("credential reuse error was not actionable: %s",
+			response.Body.String())
+	}
+}
+
+func TestAuditLLMModelDiscoveryRoleGateIsConcurrent(t *testing.T) {
+	var privateRequests atomic.Int32
+	privateServer := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			privateRequests.Add(1)
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		},
+	))
+	defer privateServer.Close()
+
+	cfg := &config.Config{}
+	cfg.LLM.APIKey = "configured-secret"
+	handler := auditLLMModelsRouter(cfg)
+	body := `{"config":{"llm.endpoint":"` + privateServer.URL + `"}}`
+	const callers = 16
+	statuses := make(chan int, callers)
+	for range callers {
+		go func() {
+			statuses <- auditModelsRequest(t, handler, "viewer", body).Code
+		}()
+	}
+	for range callers {
+		if got := <-statuses; got != http.StatusForbidden {
+			t.Fatalf("concurrent viewer status = %d, want 403", got)
+		}
+	}
+	if got := privateRequests.Load(); got != 0 {
+		t.Fatalf("private endpoint received %d requests, want 0", got)
+	}
+}
+
+// No database integration test: model discovery is stateless and its only
+// side effect is the HTTP request asserted by the in-process provider above.
+// Nil/empty input is covered by invalid JSON and the configured-field checks
+// already present in llm_handlers_test.go.

--- a/sidecar/internal/api/llm_endpoint_security.go
+++ b/sidecar/internal/api/llm_endpoint_security.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+func validateLLMDiscoveryEndpoint(ctx context.Context, endpoint string) error {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("parse endpoint: %w", err)
+	}
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return fmt.Errorf("endpoint scheme must be http or https")
+	}
+	if parsed.Hostname() == "" {
+		return fmt.Errorf("endpoint host is required")
+	}
+	if parsed.User != nil {
+		return fmt.Errorf("endpoint userinfo is forbidden")
+	}
+	host := strings.TrimSuffix(strings.ToLower(parsed.Hostname()), ".")
+	if host == "metadata.google.internal" {
+		return fmt.Errorf("metadata endpoint is forbidden")
+	}
+	addresses, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil || len(addresses) == 0 {
+		return fmt.Errorf("endpoint DNS lookup failed")
+	}
+	for _, address := range addresses {
+		if unsafeLLMEndpointIP(address.IP) {
+			return fmt.Errorf("endpoint resolves to a non-public address")
+		}
+	}
+	return nil
+}
+
+func unsafeLLMEndpointIP(ip net.IP) bool {
+	return ip == nil || ip.IsLoopback() || ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified() || ip.IsMulticast()
+}
+
+func sameLLMEndpoint(left, right string) bool {
+	leftURL, leftErr := url.Parse(strings.TrimRight(left, "/"))
+	rightURL, rightErr := url.Parse(strings.TrimRight(right, "/"))
+	if leftErr != nil || rightErr != nil {
+		return false
+	}
+	return strings.EqualFold(leftURL.Scheme, rightURL.Scheme) &&
+		strings.EqualFold(leftURL.Host, rightURL.Host) &&
+		leftURL.EscapedPath() == rightURL.EscapedPath()
+}
+
+func safeLLMDiscoveryHTTPClient() *http.Client {
+	dialer := &net.Dialer{}
+	transport := &http.Transport{
+		Proxy: nil,
+		DialContext: func(
+			ctx context.Context, network, address string,
+		) (net.Conn, error) {
+			return dialSafeLLMEndpoint(ctx, dialer, network, address)
+		},
+	}
+	return &http.Client{
+		Transport: transport,
+		CheckRedirect: func(
+			_ *http.Request, _ []*http.Request,
+		) error {
+			return fmt.Errorf("provider redirects are forbidden")
+		},
+	}
+}
+
+func dialSafeLLMEndpoint(
+	ctx context.Context,
+	dialer *net.Dialer,
+	network string,
+	address string,
+) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("split provider address: %w", err)
+	}
+	addresses, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil || len(addresses) == 0 {
+		return nil, fmt.Errorf("provider DNS lookup failed")
+	}
+	for _, resolved := range addresses {
+		if unsafeLLMEndpointIP(resolved.IP) {
+			return nil, fmt.Errorf("provider resolved to a non-public address")
+		}
+	}
+	for _, resolved := range addresses {
+		pinned := net.JoinHostPort(resolved.IP.String(), port)
+		conn, dialErr := dialer.DialContext(ctx, network, pinned)
+		if dialErr == nil {
+			return conn, nil
+		}
+		err = dialErr
+	}
+	return nil, fmt.Errorf("connect to provider: %w", err)
+}

--- a/sidecar/internal/api/llm_handlers.go
+++ b/sidecar/internal/api/llm_handlers.go
@@ -50,6 +50,9 @@ func discoverModelsHandler(
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		discoveryCfg := *cfg
+		configuredEndpoint := discoveryCfg.Endpoint
+		endpointSupplied := false
+		apiKeySupplied := false
 		var req modelDiscoveryRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			jsonError(w, "invalid JSON", http.StatusBadRequest)
@@ -63,12 +66,29 @@ func discoverModelsHandler(
 			switch key {
 			case "llm.endpoint":
 				discoveryCfg.Endpoint = value
+				endpointSupplied = true
 			case "llm.api_key":
 				if !isMaskedSecretUpdate(key, value) {
 					discoveryCfg.APIKey = value
+					apiKeySupplied = value != ""
 				}
 			case "llm.model":
 				discoveryCfg.Model = value
+			}
+		}
+		if endpointSupplied {
+			if err := validateLLMDiscoveryEndpoint(
+				r.Context(), discoveryCfg.Endpoint,
+			); err != nil {
+				jsonError(w, "invalid LLM endpoint", http.StatusBadRequest)
+				return
+			}
+			if !sameLLMEndpoint(discoveryCfg.Endpoint, configuredEndpoint) &&
+				!apiKeySupplied {
+				jsonError(w,
+					"API key required for endpoint override",
+					http.StatusBadRequest)
+				return
 			}
 		}
 
@@ -79,8 +99,14 @@ func discoverModelsHandler(
 			return
 		}
 
-		models, err := llm.ListModels(
-			r.Context(), discoveryCfg.Endpoint, discoveryCfg.APIKey)
+		httpClient := http.DefaultClient
+		if endpointSupplied {
+			httpClient = safeLLMDiscoveryHTTPClient()
+		}
+		models, err := llm.ListModelsWithClient(
+			r.Context(), discoveryCfg.Endpoint,
+			discoveryCfg.APIKey, httpClient,
+		)
 		if err != nil {
 			slog.Error("LLM list models failed", "error", err)
 			jsonError(w, "LLM request failed",

--- a/sidecar/internal/api/llm_handlers_test.go
+++ b/sidecar/internal/api/llm_handlers_test.go
@@ -147,11 +147,13 @@ func TestDiscoverModelsHandler_UsesRequestPayload(t *testing.T) {
 
 	llm.InvalidateModelCache()
 
-	cfg := &config.LLMConfig{}
+	// The endpoint is trusted configuration. Request payloads may supply a
+	// credential/model for discovery, but must not redirect configured
+	// credentials to an arbitrary private host.
+	cfg := &config.LLMConfig{Endpoint: srv.URL}
 	handler := discoverModelsHandler(cfg)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/llm/models",
 		strings.NewReader(`{"config":{
-			"llm.endpoint":"`+srv.URL+`",
 			"llm.api_key":"payload-key",
 			"llm.model":"payload-model"
 		}}`))
@@ -162,7 +164,7 @@ func TestDiscoverModelsHandler_UsesRequestPayload(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
-	if cfg.Endpoint != "" || cfg.APIKey != "" {
+	if cfg.Endpoint != srv.URL || cfg.APIKey != "" {
 		t.Fatalf("handler persisted discovery payload into cfg: %+v", cfg)
 	}
 }

--- a/sidecar/internal/api/router.go
+++ b/sidecar/internal/api/router.go
@@ -324,9 +324,9 @@ func registerAPIRoutes(
 	mux.HandleFunc(
 		"GET /api/v1/llm/models",
 		listModelsHandler(&cfg.LLM))
-	mux.HandleFunc(
+	mux.Handle(
 		"POST /api/v1/llm/models",
-		discoverModelsHandler(&cfg.LLM))
+		adminOnly(http.HandlerFunc(discoverModelsHandler(&cfg.LLM))))
 	mux.HandleFunc(
 		"GET /api/v1/llm/status",
 		llmStatusHandler(llmMgr))

--- a/sidecar/internal/autoexplain/audit_parameterized_capture_test.go
+++ b/sidecar/internal/autoexplain/audit_parameterized_capture_test.go
@@ -1,0 +1,84 @@
+package autoexplain
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pg-sage/sidecar/internal/schema"
+)
+
+func TestCaptureOnDemand_NormalizedParameterizedQuery(t *testing.T) {
+	pool := requireAuditFixturePool(t)
+	ctx := context.Background()
+	bootstrapCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := schema.Bootstrap(bootstrapCtx, pool); err != nil {
+		t.Fatalf("bootstrap designated fixture schema: %v", err)
+	}
+	queryID := int64(999999908)
+	query := "SELECT $1::integer"
+
+	cleanup := func() {
+		_, _ = pool.Exec(ctx,
+			"DELETE FROM sage.explain_cache WHERE queryid = $1", queryID)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	collector := NewCollector(
+		pool,
+		CollectorConfig{
+			CollectIntervalSeconds: 60,
+			MaxPlansPerCycle:       5,
+			LogMinDurationMs:       100,
+		},
+		&Availability{Available: false, Method: "unavailable"},
+		func(string, string, ...any) {},
+	)
+
+	if err := collector.captureOnDemand(ctx, queryID, query); err != nil {
+		t.Fatalf("capture normalized parameterized query: %v", err)
+	}
+
+	var storedQuery string
+	var planJSON []byte
+	if err := pool.QueryRow(ctx, `
+		SELECT query_text, plan_json
+		  FROM sage.explain_cache
+		 WHERE queryid = $1
+		 ORDER BY captured_at DESC
+		 LIMIT 1`, queryID).Scan(&storedQuery, &planJSON); err != nil {
+		t.Fatalf("read captured parameterized plan: %v", err)
+	}
+	if storedQuery != query {
+		t.Fatalf("stored query = %q, want %q", storedQuery, query)
+	}
+	if len(planJSON) == 0 {
+		t.Fatal("captured parameterized plan is empty")
+	}
+}
+
+
+func requireAuditFixturePool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := strings.TrimSpace(os.Getenv("SAGE_TEST_DATABASE_URL"))
+	if dsn == "" || strings.Contains(dsn, "pgsage_test_disabled") {
+		t.Skip("SKIPPED: SAGE_TEST_DATABASE_URL fixture is not configured")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("create designated fixture pool: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Fatalf("ping designated fixture: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}

--- a/sidecar/internal/autoexplain/collector.go
+++ b/sidecar/internal/autoexplain/collector.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pg-sage/sidecar/internal/sanitize"
 	"github.com/pg-sage/sidecar/internal/selfmonitor"
@@ -168,20 +171,52 @@ func (c *Collector) captureOnDemand(
 	_, _ = tx.Exec(ctx, "SET LOCAL statement_timeout = '5s'")
 	_, _ = tx.Exec(ctx, "SET TRANSACTION READ ONLY")
 
-	explainSQL := fmt.Sprintf(
-		"EXPLAIN (FORMAT JSON) %s", query,
-	)
-	var planJSON []byte
-	if err := tx.QueryRow(ctx, explainSQL).Scan(
-		&planJSON,
-	); err != nil {
-		return fmt.Errorf("explain: %w", err)
+	planJSON, err := capturePlanJSON(ctx, tx, query)
+	if err != nil {
+		return err
 	}
 
 	totalCost, execTime := extractPlanMetrics(planJSON)
 	return c.storePlan(
 		ctx, queryID, query, planJSON, totalCost, execTime,
 	)
+}
+
+var parameterPlaceholder = regexp.MustCompile(`\$([1-9][0-9]*)`)
+
+func capturePlanJSON(ctx context.Context, tx pgx.Tx, query string) ([]byte, error) {
+	count := parameterCount(query)
+	if count == 0 {
+		return scanPlanJSON(ctx, tx, "EXPLAIN (FORMAT JSON) "+query)
+	}
+	const statement = "pg_sage_autoexplain"
+	if _, err := tx.Exec(ctx, "PREPARE "+statement+" AS "+query); err != nil {
+		return nil, fmt.Errorf("prepare parameterized query: %w", err)
+	}
+	defer func() { _, _ = tx.Exec(ctx, "DEALLOCATE "+statement) }()
+	params := strings.TrimSuffix(strings.Repeat("NULL,", count), ",")
+	return scanPlanJSON(ctx, tx, fmt.Sprintf(
+		"EXPLAIN (FORMAT JSON) EXECUTE %s(%s)", statement, params,
+	))
+}
+
+func scanPlanJSON(ctx context.Context, tx pgx.Tx, sql string) ([]byte, error) {
+	var planJSON []byte
+	if err := tx.QueryRow(ctx, sql).Scan(&planJSON); err != nil {
+		return nil, fmt.Errorf("explain: %w", err)
+	}
+	return planJSON, nil
+}
+
+func parameterCount(query string) int {
+	maxParam := 0
+	for _, match := range parameterPlaceholder.FindAllStringSubmatch(query, -1) {
+		param, err := strconv.Atoi(match[1])
+		if err == nil && param > maxParam {
+			maxParam = param
+		}
+	}
+	return maxParam
 }
 
 // storePlan inserts a captured plan into sage.explain_cache.

--- a/sidecar/internal/collector/catalog_query.go
+++ b/sidecar/internal/collector/catalog_query.go
@@ -1,0 +1,107 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/jackc/pgx/v5"
+)
+
+type catalogQuerier interface {
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+type timedCatalogQuerier struct{ collector *Collector }
+
+func (q timedCatalogQuerier) Query(
+	ctx context.Context, sql string, args ...any,
+) (pgx.Rows, error) {
+	return q.collector.catalogQuery(ctx, sql, args...)
+}
+
+func (q timedCatalogQuerier) QueryRow(
+	ctx context.Context, sql string, args ...any,
+) pgx.Row {
+	return q.collector.catalogQueryRow(ctx, sql, args...)
+}
+
+type catalogRows struct {
+	pgx.Rows
+	tx     pgx.Tx
+	closed bool
+}
+
+func (r *catalogRows) Next() bool {
+	if r.Rows.Next() {
+		return true
+	}
+	r.Close()
+	return false
+}
+
+func (r *catalogRows) Close() {
+	if r.closed {
+		return
+	}
+	r.closed = true
+	r.Rows.Close()
+	_ = r.tx.Rollback(context.Background())
+}
+
+type catalogRow struct {
+	row pgx.Row
+	tx  pgx.Tx
+	err error
+}
+
+func (r catalogRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	defer func() { _ = r.tx.Rollback(context.Background()) }()
+	return r.row.Scan(dest...)
+}
+
+func (c *Collector) beginCatalogQuery(ctx context.Context) (pgx.Tx, error) {
+	tx, err := c.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin collector catalog query: %w", err)
+	}
+	statementMs := strconv.Itoa(c.cfg.Safety.QueryTimeoutMs) + "ms"
+	lockMs := strconv.Itoa(c.cfg.Safety.LockTimeout()) + "ms"
+	_, err = tx.Exec(ctx, `SELECT
+		set_config('statement_timeout', $1, true),
+		set_config('lock_timeout', $2, true)`, statementMs, lockMs)
+	if err != nil {
+		_ = tx.Rollback(context.Background())
+		return nil, fmt.Errorf("set collector catalog timeouts: %w", err)
+	}
+	return tx, nil
+}
+
+func (c *Collector) catalogQuery(
+	ctx context.Context, sql string, args ...any,
+) (pgx.Rows, error) {
+	tx, err := c.beginCatalogQuery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := tx.Query(ctx, sql, args...)
+	if err != nil {
+		_ = tx.Rollback(context.Background())
+		return nil, err
+	}
+	return &catalogRows{Rows: rows, tx: tx}, nil
+}
+
+func (c *Collector) catalogQueryRow(
+	ctx context.Context, sql string, args ...any,
+) pgx.Row {
+	tx, err := c.beginCatalogQuery(ctx)
+	if err != nil {
+		return catalogRow{err: err}
+	}
+	return catalogRow{row: tx.QueryRow(ctx, sql, args...), tx: tx}
+}

--- a/sidecar/internal/collector/circuit_breaker.go
+++ b/sidecar/internal/collector/circuit_breaker.go
@@ -3,8 +3,6 @@ package collector
 import (
 	"context"
 	"sync"
-
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // CircuitBreaker prevents collection when the database is under heavy load.
@@ -28,7 +26,7 @@ func NewCircuitBreaker(cpuCeilingPct, maxSkips int) *CircuitBreaker {
 
 // ShouldSkip checks active_backends / max_connections against the ceiling.
 // Returns true if the current cycle should be skipped.
-func (cb *CircuitBreaker) ShouldSkip(ctx context.Context, pool *pgxpool.Pool) bool {
+func (cb *CircuitBreaker) ShouldSkip(ctx context.Context, pool catalogQuerier) bool {
 	var loadRatio float64
 	err := pool.QueryRow(ctx, loadRatioSQL).Scan(&loadRatio)
 	if err != nil {

--- a/sidecar/internal/collector/collector.go
+++ b/sidecar/internal/collector/collector.go
@@ -14,16 +14,16 @@ import (
 
 // Collector runs periodic stats collection against the target database.
 type Collector struct {
-	pool         *pgxpool.Pool
-	cfg          *config.Config
-	breaker      *CircuitBreaker
+	pool            *pgxpool.Pool
+	cfg             *config.Config
+	breaker         *CircuitBreaker
 	mu              sync.RWMutex
 	latest          *Snapshot
 	previous        *Snapshot
 	tablePageSchema string
 	tablePageRel    string
 	pgVersionNum    int // e.g. 170009 for PG 17.9
-	logFn        func(string, string, ...any)
+	logFn           func(string, string, ...any)
 }
 
 // New creates a Collector wired to the given pool and config.
@@ -65,7 +65,7 @@ func (c *Collector) Run(ctx context.Context) {
 }
 
 func (c *Collector) cycle(ctx context.Context, ticker *time.Ticker) {
-	if c.breaker.ShouldSkip(ctx, c.pool) {
+	if c.breaker.ShouldSkip(ctx, timedCatalogQuerier{collector: c}) {
 		if c.breaker.IsDormant() {
 			c.logFn("WARN", "circuit breaker dormant, using dormant interval")
 			ticker.Reset(c.cfg.Safety.DormantInterval())
@@ -192,7 +192,8 @@ func (c *Collector) collect(ctx context.Context) (*Snapshot, error) {
 	}
 	// Config data for advisor features
 	if c.cfg.Advisor.Enabled {
-		if snap.ConfigData, err = collectConfigSnapshot(ctx, c.pool); err != nil {
+		querier := timedCatalogQuerier{collector: c}
+		if snap.ConfigData, err = collectConfigSnapshot(ctx, querier); err != nil {
 			c.logFn("WARN", "config snapshot collection failed: %v", err)
 		}
 	}
@@ -232,7 +233,7 @@ func (c *Collector) collectQueries(ctx context.Context) ([]QueryStats, error) {
 	}
 	sql := fmt.Sprintf(tpl, limit)
 
-	rows, err := c.pool.Query(ctx, sql)
+	rows, err := c.catalogQuery(ctx, sql)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +277,7 @@ func (c *Collector) collectTables(ctx context.Context) ([]TableStats, error) {
 	pageSchema := c.tablePageSchema
 	pageRel := c.tablePageRel
 	for {
-		rows, err := c.pool.Query(ctx, tableStatsSQL, pageSchema, pageRel, batchSize)
+		rows, err := c.catalogQuery(ctx, tableStatsSQL, pageSchema, pageRel, batchSize)
 		if err != nil {
 			return nil, err
 		}
@@ -329,7 +330,7 @@ func (c *Collector) collectTables(ctx context.Context) ([]TableStats, error) {
 }
 
 func (c *Collector) collectIndexes(ctx context.Context) ([]IndexStats, error) {
-	rows, err := c.pool.Query(ctx, indexStatsSQL)
+	rows, err := c.catalogQuery(ctx, indexStatsSQL)
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +354,7 @@ func (c *Collector) collectIndexes(ctx context.Context) ([]IndexStats, error) {
 }
 
 func (c *Collector) collectForeignKeys(ctx context.Context) ([]ForeignKey, error) {
-	rows, err := c.pool.Query(ctx, foreignKeysSQL)
+	rows, err := c.catalogQuery(ctx, foreignKeysSQL)
 	if err != nil {
 		return nil, err
 	}
@@ -380,7 +381,7 @@ func (c *Collector) collectSystem(ctx context.Context) (SystemStats, error) {
 	}
 
 	var s SystemStats
-	err := c.pool.QueryRow(ctx, sql).Scan(
+	err := c.catalogQueryRow(ctx, sql).Scan(
 		&s.ActiveBackends, &s.IdleInTransaction,
 		&s.TotalBackends, &s.MaxConnections,
 		&s.CacheHitRatio, &s.Deadlocks,
@@ -392,7 +393,7 @@ func (c *Collector) collectSystem(ctx context.Context) (SystemStats, error) {
 }
 
 func (c *Collector) collectLocks(ctx context.Context) ([]LockInfo, error) {
-	rows, err := c.pool.Query(ctx, locksSQL)
+	rows, err := c.catalogQuery(ctx, locksSQL)
 	if err != nil {
 		return nil, err
 	}
@@ -417,7 +418,7 @@ func (c *Collector) collectLocks(ctx context.Context) ([]LockInfo, error) {
 }
 
 func (c *Collector) collectSequences(ctx context.Context) ([]SequenceStats, error) {
-	rows, err := c.pool.Query(ctx, sequencesSQL)
+	rows, err := c.catalogQuery(ctx, sequencesSQL)
 	if err != nil {
 		return nil, err
 	}
@@ -444,12 +445,10 @@ func (c *Collector) collectReplication(
 	rs := &ReplicationStats{}
 
 	// Collect replicas.
-	replicaRows, err := c.pool.Query(ctx, replicationReplicasSQL)
+	replicaRows, err := c.catalogQuery(ctx, replicationReplicasSQL)
 	if err != nil {
 		return nil, err
 	}
-	defer replicaRows.Close()
-
 	for replicaRows.Next() {
 		var r ReplicaInfo
 		if err := replicaRows.Scan(
@@ -458,27 +457,29 @@ func (c *Collector) collectReplication(
 			&r.WriteLag, &r.FlushLag, &r.ReplayLag,
 			&r.SyncState,
 		); err != nil {
+			replicaRows.Close()
 			return nil, err
 		}
 		rs.Replicas = append(rs.Replicas, r)
 	}
 	if err := replicaRows.Err(); err != nil {
+		replicaRows.Close()
 		return nil, err
 	}
+	replicaRows.Close()
 
 	// Collect slots.
-	slotRows, err := c.pool.Query(ctx, replicationSlotsSQL)
+	slotRows, err := c.catalogQuery(ctx, replicationSlotsSQL)
 	if err != nil {
 		return nil, err
 	}
-	defer slotRows.Close()
-
 	for slotRows.Next() {
 		var s SlotInfo
 		if err := slotRows.Scan(
 			&s.SlotName, &s.SlotType, &s.Active,
 			&s.RetainedBytes,
 		); err != nil {
+			slotRows.Close()
 			return nil, err
 		}
 		rs.Slots = append(rs.Slots, s)
@@ -496,7 +497,7 @@ func (c *Collector) collectReplication(
 }
 
 func (c *Collector) collectIO(ctx context.Context) ([]IOStats, error) {
-	rows, err := c.pool.Query(ctx, ioStatsSQL)
+	rows, err := c.catalogQuery(ctx, ioStatsSQL)
 	if err != nil {
 		return nil, err
 	}
@@ -525,7 +526,7 @@ func (c *Collector) collectIO(ctx context.Context) ([]IOStats, error) {
 func (c *Collector) collectPartitions(
 	ctx context.Context,
 ) ([]PartitionInfo, error) {
-	rows, err := c.pool.Query(ctx, partitionInheritanceSQL)
+	rows, err := c.catalogQuery(ctx, partitionInheritanceSQL)
 	if err != nil {
 		return nil, err
 	}
@@ -548,7 +549,7 @@ func (c *Collector) collectPartitions(
 func (c *Collector) collectPreparedXacts(
 	ctx context.Context,
 ) ([]PreparedTransaction, error) {
-	rows, err := c.pool.Query(ctx, preparedXactsSQL)
+	rows, err := c.catalogQuery(ctx, preparedXactsSQL)
 	if err != nil {
 		return nil, err
 	}
@@ -567,4 +568,3 @@ func (c *Collector) collectPreparedXacts(
 	}
 	return result, rows.Err()
 }
-

--- a/sidecar/internal/collector/collector_helpers.go
+++ b/sidecar/internal/collector/collector_helpers.go
@@ -53,7 +53,7 @@ func (c *Collector) collectStatStatementsMax(
 	ctx context.Context,
 ) int {
 	var val int
-	err := c.pool.QueryRow(
+	err := c.catalogQueryRow(
 		ctx,
 		`/* pg_sage */ SELECT setting::int FROM pg_settings
 		 WHERE name = 'pg_stat_statements.max'`,

--- a/sidecar/internal/collector/collector_integ_test.go
+++ b/sidecar/internal/collector/collector_integ_test.go
@@ -710,3 +710,71 @@ func TestCollectQueries_CancelledContext(t *testing.T) {
 		t.Error("collectQueries with cancelled context should error")
 	}
 }
+
+func TestCollectQueries_AppliesConfiguredStatementAndLockTimeouts(t *testing.T) {
+	dsn := os.Getenv("SAGE_TEST_DATABASE_URL")
+	poolCfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse test database config: %v", err)
+	}
+	poolCfg.MaxConns = 1
+	pool, err := pgxpool.NewWithConfig(context.Background(), poolCfg)
+	if err != nil {
+		t.Fatalf("create single-connection pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	const fakeStatements = `CREATE TEMP VIEW pg_stat_statements AS
+		SELECT 1::bigint AS queryid,
+		       current_setting('statement_timeout') || '/' ||
+		           current_setting('lock_timeout') AS query,
+		       1::bigint AS calls,
+		       0::double precision AS total_exec_time,
+		       0::double precision AS mean_exec_time,
+		       0::double precision AS min_exec_time,
+		       0::double precision AS max_exec_time,
+		       0::double precision AS stddev_exec_time,
+		       0::bigint AS rows,
+		       0::bigint AS shared_blks_hit,
+		       0::bigint AS shared_blks_read,
+		       0::bigint AS shared_blks_dirtied,
+		       0::bigint AS shared_blks_written,
+		       0::bigint AS temp_blks_read,
+		       0::bigint AS temp_blks_written,
+		       (SELECT oid FROM pg_database
+		          WHERE datname = current_database()) AS dbid`
+	if _, err := pool.Exec(context.Background(), fakeStatements); err != nil {
+		t.Fatalf("create timeout-observing pg_stat_statements view: %v", err)
+	}
+
+	cfg := testConfig()
+	cfg.HasWALColumns = false
+	cfg.HasPlanTimeColumns = false
+	cfg.Safety.QueryTimeoutMs = 75
+	cfg.Safety.LockTimeoutMs = 40
+	c := New(pool, cfg, 170000, noopLog)
+
+	queries, err := c.collectQueries(context.Background())
+	if err != nil {
+		t.Fatalf("collect queries: %v", err)
+	}
+	if len(queries) != 1 {
+		t.Fatalf("collected %d queries, want 1", len(queries))
+	}
+	if got, want := queries[0].Query, "75ms/40ms"; got != want {
+		t.Fatalf("collector query timeouts = %q, want %q", got, want)
+	}
+	var statementTimeout string
+	var lockTimeout string
+	if err := pool.QueryRow(context.Background(), `SELECT
+		current_setting('statement_timeout'),
+		current_setting('lock_timeout')`).Scan(
+		&statementTimeout, &lockTimeout,
+	); err != nil {
+		t.Fatalf("read pooled session timeouts after collection: %v", err)
+	}
+	if statementTimeout != "0" || lockTimeout != "0" {
+		t.Fatalf("collector leaked timeouts into pool: statement=%q lock=%q",
+			statementTimeout, lockTimeout)
+	}
+}

--- a/sidecar/internal/collector/queries_config.go
+++ b/sidecar/internal/collector/queries_config.go
@@ -2,11 +2,9 @@ package collector
 
 import (
 	"context"
-
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-func collectConfigSnapshot(ctx context.Context, pool *pgxpool.Pool) (*ConfigSnapshot, error) {
+func collectConfigSnapshot(ctx context.Context, pool catalogQuerier) (*ConfigSnapshot, error) {
 	cs := &ConfigSnapshot{}
 
 	// pg_settings for advisor features
@@ -27,7 +25,6 @@ func collectConfigSnapshot(ctx context.Context, pool *pgxpool.Pool) (*ConfigSnap
 	if err != nil {
 		return cs, err
 	}
-	defer rows.Close()
 	for rows.Next() {
 		var s PGSetting
 		if err := rows.Scan(&s.Name, &s.Setting, &s.Unit, &s.Source, &s.PendingRestart); err != nil {
@@ -35,6 +32,7 @@ func collectConfigSnapshot(ctx context.Context, pool *pgxpool.Pool) (*ConfigSnap
 		}
 		cs.PGSettings = append(cs.PGSettings, s)
 	}
+	rows.Close()
 
 	// Table reloptions (autovacuum overrides)
 	rows2, err := pool.Query(ctx, `/* pg_sage */ 
@@ -45,7 +43,6 @@ func collectConfigSnapshot(ctx context.Context, pool *pgxpool.Pool) (*ConfigSnap
 		  AND c.relkind = 'r'
 		  AND c.reloptions IS NOT NULL`)
 	if err == nil {
-		defer rows2.Close()
 		for rows2.Next() {
 			var t TableReloption
 			if err := rows2.Scan(&t.SchemaName, &t.RelName, &t.Reloptions); err != nil {
@@ -53,6 +50,7 @@ func collectConfigSnapshot(ctx context.Context, pool *pgxpool.Pool) (*ConfigSnap
 			}
 			cs.TableReloptions = append(cs.TableReloptions, t)
 		}
+		rows2.Close()
 	}
 
 	// Connection state distribution
@@ -64,7 +62,6 @@ func collectConfigSnapshot(ctx context.Context, pool *pgxpool.Pool) (*ConfigSnap
 		  AND datname = current_database()
 		GROUP BY state`)
 	if err == nil {
-		defer rows3.Close()
 		for rows3.Next() {
 			var c ConnectionState
 			if err := rows3.Scan(&c.State, &c.Count, &c.AvgDurationSeconds); err != nil {
@@ -72,6 +69,7 @@ func collectConfigSnapshot(ctx context.Context, pool *pgxpool.Pool) (*ConfigSnap
 			}
 			cs.ConnectionStates = append(cs.ConnectionStates, c)
 		}
+		rows3.Close()
 	}
 
 	// WAL position
@@ -86,7 +84,6 @@ func collectConfigSnapshot(ctx context.Context, pool *pgxpool.Pool) (*ConfigSnap
 		SELECT name FROM pg_available_extensions
 		WHERE name IN ('pg_repack','pg_buffercache','pgstattuple','hypopg')`)
 	if err == nil {
-		defer rows4.Close()
 		for rows4.Next() {
 			var name string
 			if err := rows4.Scan(&name); err != nil {
@@ -94,6 +91,7 @@ func collectConfigSnapshot(ctx context.Context, pool *pgxpool.Pool) (*ConfigSnap
 			}
 			cs.ExtensionsAvailable = append(cs.ExtensionsAvailable, name)
 		}
+		rows4.Close()
 	}
 
 	// Connection churn (new connections in last 5 minutes)

--- a/sidecar/internal/executor/action_policy.go
+++ b/sidecar/internal/executor/action_policy.go
@@ -41,6 +41,7 @@ func EvaluateActionPolicy(
 	contract ActionContract,
 	ctx ActionPolicyContext,
 ) ActionPolicyDecision {
+	ctx.Config = snapshotPolicyConfig(ctx.Config)
 	decision := newPolicyDecision(contract, ctx)
 	if blocked := hardBlockReason(contract, ctx, decision.Provider); blocked != "" {
 		decision.Decision = PolicyDecisionBlocked
@@ -87,6 +88,18 @@ func EvaluateActionPolicy(
 		decision.BlockedReason = "unknown or prohibited risk tier"
 	}
 	return decision
+}
+
+func snapshotPolicyConfig(cfg *config.Config) *config.Config {
+	if cfg == nil {
+		return nil
+	}
+	config.RLockForHotReload()
+	defer config.RUnlockForHotReload()
+	return &config.Config{
+		CloudEnvironment: cfg.CloudEnvironment,
+		Trust:            cfg.Trust,
+	}
 }
 
 func newPolicyDecision(

--- a/sidecar/internal/executor/action_policy_race_audit_test.go
+++ b/sidecar/internal/executor/action_policy_race_audit_test.go
@@ -1,0 +1,63 @@
+package executor
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pg-sage/sidecar/internal/config"
+)
+
+// TestEvaluateActionPolicyConcurrentHotReload is primarily a race-detector
+// regression test. A live config writer uses the documented hot-reload lock;
+// policy evaluation must use the matching read lock before copying fields.
+func TestEvaluateActionPolicyConcurrentHotReload(t *testing.T) {
+	cfg := &config.Config{
+		Trust: config.TrustConfig{
+			Level:         "autonomous",
+			Tier3Safe:     true,
+			Tier3Moderate: true,
+		},
+	}
+	contract := ActionContract{
+		ActionType:   "create_index",
+		BaseRiskTier: "safe",
+	}
+	ctx := ActionPolicyContext{
+		Config:        cfg,
+		ExecutionMode: "auto",
+		Now:           time.Now(),
+		RampStart:     time.Now().Add(-32 * 24 * time.Hour),
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1_000; i++ {
+			config.LockForHotReload()
+			if i%2 == 0 {
+				cfg.Trust.Level = "observation"
+			} else {
+				cfg.Trust.Level = "autonomous"
+			}
+			config.UnlockForHotReload()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1_000; i++ {
+			decision := EvaluateActionPolicy(contract, ctx)
+			switch decision.Decision {
+			case PolicyDecisionExecute, PolicyDecisionObserveOnly:
+			default:
+				t.Errorf("unexpected decision during reload: %q", decision.Decision)
+				return
+			}
+		}
+	}()
+	wg.Wait()
+}
+
+// No integration test: policy evaluation is a pure in-memory boundary and the
+// production race is exercised directly with the same package-level lock.

--- a/sidecar/internal/executor/trust.go
+++ b/sidecar/internal/executor/trust.go
@@ -103,48 +103,28 @@ func inMaintenanceWindowAt(cronExpr string, now time.Time) bool {
 	}
 
 	parts := strings.Fields(s)
-	if len(parts) < 2 {
+	if len(parts) != 5 || !cronCalendarMatches(parts[2:], now) {
 		return false
 	}
+	return cronTimeMatches(parts[0], parts[1], now)
+}
 
-	// Parse minute field: "*" means any minute.
-	minuteWild := parts[0] == "*"
-	var minute int
-	if !minuteWild {
-		var err error
-		minute, err = strconv.Atoi(parts[0])
-		if err != nil {
-			return false
-		}
+func cronTimeMatches(minuteField, hourField string, now time.Time) bool {
+	minute, minuteWild, minuteOK := cronTimeField(minuteField, 0, 59)
+	hour, hourWild, hourOK := cronTimeField(hourField, 0, 23)
+	if !minuteOK || !hourOK {
+		return false
 	}
-
-	// Parse hour field: "*" means any hour.
-	hourWild := parts[1] == "*"
-	var hour int
-	if !hourWild {
-		var err error
-		hour, err = strconv.Atoi(parts[1])
-		if err != nil {
-			return false
-		}
-	}
-
-	// Both wildcards → always in window.
 	if minuteWild && hourWild {
 		return true
 	}
-
 	if hourWild {
-		// Any hour, specific minute: 1-hour window starting at :minute.
 		windowStart := time.Date(
 			now.Year(), now.Month(), now.Day(),
 			now.Hour(), minute, 0, 0, now.Location(),
 		)
-		windowEnd := windowStart.Add(1 * time.Hour)
-		return !now.Before(windowStart) && now.Before(windowEnd)
+		return inCronHour(now, windowStart)
 	}
-
-	// Specific hour (minute may be wild or specific).
 	if minuteWild {
 		minute = 0
 	}
@@ -152,9 +132,54 @@ func inMaintenanceWindowAt(cronExpr string, now time.Time) bool {
 		now.Year(), now.Month(), now.Day(),
 		hour, minute, 0, 0, now.Location(),
 	)
-	windowEnd := windowStart.Add(1 * time.Hour)
+	return inCronHour(now, windowStart)
+}
 
-	return !now.Before(windowStart) && now.Before(windowEnd)
+func cronTimeField(field string, minValue, maxValue int) (int, bool, bool) {
+	if field == "*" {
+		return 0, true, true
+	}
+	value, err := strconv.Atoi(field)
+	return value, false, err == nil && value >= minValue && value <= maxValue
+}
+
+func inCronHour(now, start time.Time) bool {
+	return !now.Before(start) && now.Before(start.Add(time.Hour))
+}
+
+func cronCalendarMatches(fields []string, now time.Time) bool {
+	domMatch, domWild := cronNumberMatches(fields[0], now.Day(), 1, 31, false)
+	monthMatch, _ := cronNumberMatches(fields[1], int(now.Month()), 1, 12, false)
+	dowMatch, dowWild := cronNumberMatches(fields[2], int(now.Weekday()), 0, 7, true)
+	if !monthMatch {
+		return false
+	}
+	switch {
+	case domWild && dowWild:
+		return true
+	case domWild:
+		return dowMatch
+	case dowWild:
+		return domMatch
+	default:
+		return domMatch || dowMatch
+	}
+}
+
+func cronNumberMatches(
+	field string, value, minValue, maxValue int, sundayAlias bool,
+) (match, wildcard bool) {
+	if field == "*" {
+		return true, true
+	}
+	parsed, err := strconv.Atoi(field)
+	if err != nil || parsed < minValue || parsed > maxValue {
+		return false, false
+	}
+	if sundayAlias && parsed == 7 {
+		parsed = 0
+	}
+	return parsed == value, false
 }
 
 // maintenancePresets map friendly names to a canonical maintenance-window

--- a/sidecar/internal/executor/trust_test.go
+++ b/sidecar/internal/executor/trust_test.go
@@ -67,3 +67,61 @@ func TestInMaintenanceWindow_TimeRange(t *testing.T) {
 		}
 	}
 }
+
+func TestInMaintenanceWindow_CronHonorsDayOfMonthAndWeek(t *testing.T) {
+	date := func(year int, month time.Month, day int) time.Time {
+		return time.Date(year, month, day, 2, 30, 0, 0, time.UTC)
+	}
+	cases := []struct {
+		name string
+		expr string
+		now  time.Time
+		want bool
+	}{
+		{
+			name: "Sunday schedule rejects Monday",
+			expr: "0 2 * * 0",
+			now:  date(2026, time.July, 20),
+			want: false,
+		},
+		{
+			name: "Sunday schedule accepts Sunday",
+			expr: "0 2 * * 0",
+			now:  date(2026, time.July, 19),
+			want: true,
+		},
+		{
+			name: "day of month rejects adjacent date",
+			expr: "0 2 15 * *",
+			now:  date(2026, time.July, 14),
+			want: false,
+		},
+		{
+			name: "day of month accepts matching date",
+			expr: "0 2 15 * *",
+			now:  date(2026, time.July, 15),
+			want: true,
+		},
+		{
+			name: "restricted DOM and DOW use cron OR semantics",
+			expr: "0 2 15 * 1",
+			now:  date(2026, time.July, 20),
+			want: true,
+		},
+		{
+			name: "restricted DOM and DOW reject when neither matches",
+			expr: "0 2 15 * 1",
+			now:  date(2026, time.July, 14),
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := inMaintenanceWindowAt(tc.expr, tc.now); got != tc.want {
+				t.Fatalf("inMaintenanceWindowAt(%q, %s) = %v, want %v",
+					tc.expr, tc.now.Format("2006-01-02 Mon 15:04"), got, tc.want)
+			}
+		})
+	}
+}

--- a/sidecar/internal/fleet/budget.go
+++ b/sidecar/internal/fleet/budget.go
@@ -47,6 +47,9 @@ func (b *FleetBudget) Spend(database string, tokens int) {
 	defer b.mu.Unlock()
 	if db := b.perDB[database]; db != nil {
 		db.used += tokens
+		if db.used < 0 {
+			db.used = 0
+		}
 	}
 }
 

--- a/sidecar/internal/fleet/manager.go
+++ b/sidecar/internal/fleet/manager.go
@@ -191,22 +191,48 @@ func (m *DatabaseManager) RecordHealthSnapshots(ctx context.Context) {
 	m.mu.RUnlock()
 
 	for _, x := range samples {
-		qctx, cancel := context.WithTimeout(ctx, 3*time.Second)
-		_, err := x.pool.Exec(qctx,
-			`/* pg_sage */ INSERT INTO sage.health_history
-			 (database_name, health_score, findings_open,
-			  findings_critical, findings_warning,
-			  findings_info, actions_total)
-			 VALUES ($1,$2,$3,$4,$5,$6,$7)`,
-			x.name, x.s.HealthScore, x.s.FindingsOpen,
-			x.s.FindingsCritical, x.s.FindingsWarning,
-			x.s.FindingsInfo, x.s.ActionsTotal,
-		)
-		cancel()
-		if err != nil {
-			log.Printf("fleet: %s: health_history write failed: %v",
-				x.name, err)
-		}
+		recordHealthSample(ctx, x.name, x.pool, x.s)
+	}
+}
+
+// RecordHealthSnapshot persists one instance's current fleet health. Per-DB
+// orchestrators use this instead of recording the entire fleet on every tick.
+func (m *DatabaseManager) RecordHealthSnapshot(
+	ctx context.Context, name string,
+) {
+	m.mu.RLock()
+	inst := m.instances[name]
+	if inst == nil || inst.Pool == nil {
+		m.mu.RUnlock()
+		return
+	}
+	pool := inst.Pool
+	snapshot := inst.SnapshotStatus()
+	m.mu.RUnlock()
+	snapshot.HealthScore = computeHealthScore(snapshot)
+	recordHealthSample(ctx, name, pool, snapshot)
+}
+
+func recordHealthSample(
+	ctx context.Context,
+	name string,
+	pool *pgxpool.Pool,
+	snapshot *InstanceStatus,
+) {
+	qctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	_, err := pool.Exec(qctx,
+		`/* pg_sage */ INSERT INTO sage.health_history
+		 (database_name, health_score, findings_open,
+		  findings_critical, findings_warning,
+		  findings_info, actions_total)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+		name, snapshot.HealthScore, snapshot.FindingsOpen,
+		snapshot.FindingsCritical, snapshot.FindingsWarning,
+		snapshot.FindingsInfo, snapshot.ActionsTotal,
+	)
+	if err != nil {
+		log.Printf("fleet: %s: health_history write failed: %v", name, err)
 	}
 }
 

--- a/sidecar/internal/llm/audit_throttle_identity_test.go
+++ b/sidecar/internal/llm/audit_throttle_identity_test.go
@@ -1,0 +1,124 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/pg-sage/sidecar/internal/config"
+)
+
+func auditThrottleClient(endpoint string) *Client {
+	return New(&config.LLMConfig{
+		Enabled:          true,
+		Endpoint:         endpoint,
+		APIKey:           "audit-key",
+		Model:            "audit-model",
+		TimeoutSeconds:   5,
+		TokenBudgetDaily: 100_000,
+		CooldownSeconds:  300,
+	}, noopLog)
+}
+
+func TestAuditCooldownIsScopedToLogicalWorkItem(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			requests.Add(1)
+			_, _ = w.Write(testChatJSON("[]", 1))
+		},
+	))
+	defer server.Close()
+	client := auditThrottleClient(server.URL)
+
+	for _, prompt := range []string{
+		"optimize public.orders",
+		"optimize public.customers",
+		"prepare incident briefing",
+		"explain slow query 42",
+	} {
+		if _, _, err := client.Chat(t.Context(), "system", prompt, 10); err != nil {
+			t.Fatalf("distinct work item %q was throttled: %v", prompt, err)
+		}
+	}
+	if got := requests.Load(); got != 4 {
+		t.Fatalf("provider requests = %d, want 4", got)
+	}
+}
+
+func TestAuditCooldownStillRejectsImmediateDuplicate(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			requests.Add(1)
+			_, _ = w.Write(testChatJSON("[]", 1))
+		},
+	))
+	defer server.Close()
+	client := auditThrottleClient(server.URL)
+
+	if _, _, err := client.Chat(t.Context(), "system", "same work", 10); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	_, _, err := client.Chat(t.Context(), "system", "same work", 10)
+	if !errors.Is(err, ErrRequestCooldown) {
+		t.Fatalf("duplicate error = %v, want ErrRequestCooldown", err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("provider requests = %d, want 1", got)
+	}
+}
+
+func TestAuditConcurrentDistinctWorkItemsAreNotMutuallyThrottled(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			requests.Add(1)
+			_, _ = w.Write(testChatJSON("[]", 1))
+		},
+	))
+	defer server.Close()
+	client := auditThrottleClient(server.URL)
+
+	const count = 10
+	var wg sync.WaitGroup
+	errorsSeen := make(chan error, count)
+	for i := range count {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, err := client.Chat(
+				context.Background(), "system", "table-"+string(rune('A'+i)), 10,
+			)
+			errorsSeen <- err
+		}()
+	}
+	wg.Wait()
+	close(errorsSeen)
+	for err := range errorsSeen {
+		if err != nil {
+			t.Fatalf("distinct concurrent call failed: %v", err)
+		}
+	}
+	if got := requests.Load(); got != count {
+		t.Fatalf("provider requests = %d, want %d", got, count)
+	}
+}
+
+func TestAuditModelDiscoveryRejectsNilHTTPClient(t *testing.T) {
+	_, err := ListModelsWithClient(
+		t.Context(), "https://example.com/v1", "key", nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "HTTP client") {
+		t.Fatalf("nil HTTP client error = %v, want actionable rejection", err)
+	}
+}
+
+// Invalid/nil input is not applicable to throttle identity: Chat normalizes a
+// nil context and accepts empty prompts as valid provider input. Provider error
+// propagation and token-budget boundaries are covered by existing client tests.

--- a/sidecar/internal/llm/audit_timeout_breaker_test.go
+++ b/sidecar/internal/llm/audit_timeout_breaker_test.go
@@ -1,0 +1,110 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/pg-sage/sidecar/internal/config"
+)
+
+type auditRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn auditRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func auditTimeoutClient() *Client {
+	client := New(&config.LLMConfig{
+		Enabled:          true,
+		Endpoint:         "https://provider.invalid/v1",
+		APIKey:           "audit-key",
+		Model:            "audit-model",
+		TimeoutSeconds:   1,
+		TokenBudgetDaily: 100_000,
+		CooldownSeconds:  0,
+	}, noopLog)
+	client.httpClient.Transport = auditRoundTripFunc(
+		func(req *http.Request) (*http.Response, error) {
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		},
+	)
+	return client
+}
+
+func TestAuditProviderTimeoutsOpenCircuit(t *testing.T) {
+	client := auditTimeoutClient()
+	for i := 0; i < 3; i++ {
+		_, _, err := client.Chat(t.Context(), "system", "work", 10)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("timeout %d error = %v, want deadline exceeded", i+1, err)
+		}
+	}
+	if !client.IsCircuitOpen() {
+		t.Fatal("three provider timeouts did not open circuit")
+	}
+}
+
+func TestAuditCallerCancellationDoesNotPoisonCircuit(t *testing.T) {
+	client := auditTimeoutClient()
+	for i := 0; i < 3; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, _, err := client.Chat(ctx, "system", "work", 10)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("cancellation %d error = %v, want canceled", i+1, err)
+		}
+	}
+	if client.IsCircuitOpen() {
+		t.Fatal("caller cancellations opened provider circuit")
+	}
+}
+
+func TestAuditProviderTimeoutBoundary(t *testing.T) {
+	client := auditTimeoutClient()
+	for i := 0; i < 2; i++ {
+		if _, _, err := client.Chat(t.Context(), "system", "work", 10); err == nil {
+			t.Fatalf("timeout %d unexpectedly succeeded", i+1)
+		}
+	}
+	if client.IsCircuitOpen() {
+		t.Fatal("circuit opened before the third provider timeout")
+	}
+	if _, _, err := client.Chat(t.Context(), "system", "work", 10); err == nil {
+		t.Fatal("third timeout unexpectedly succeeded")
+	}
+	if !client.IsCircuitOpen() {
+		t.Fatal("circuit remained closed at timeout threshold")
+	}
+}
+
+func TestAuditConcurrentProviderTimeoutsOpenCircuit(t *testing.T) {
+	client := auditTimeoutClient()
+	const count = 3
+	var wg sync.WaitGroup
+	errorsSeen := make(chan error, count)
+	for range count {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, err := client.Chat(context.Background(), "system", "work", 10)
+			errorsSeen <- err
+		}()
+	}
+	wg.Wait()
+	close(errorsSeen)
+	for err := range errorsSeen {
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("concurrent timeout error = %v", err)
+		}
+	}
+	if !client.IsCircuitOpen() {
+		t.Fatal("concurrent provider timeouts did not open circuit")
+	}
+}
+
+// Nil/empty/zero config behavior is covered by client controls tests. There is
+// no database integration case: the breaker wraps an outbound HTTP provider.

--- a/sidecar/internal/llm/budget_multi_consumer_test.go
+++ b/sidecar/internal/llm/budget_multi_consumer_test.go
@@ -1,0 +1,198 @@
+package llm_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pg-sage/sidecar/internal/config"
+	"github.com/pg-sage/sidecar/internal/fleet"
+	"github.com/pg-sage/sidecar/internal/llm"
+)
+
+type scopedFleetBudget struct {
+	budget   *fleet.FleetBudget
+	database string
+}
+
+func (b scopedFleetBudget) CanSpend(tokens int) bool {
+	return b.budget.CanSpend(b.database, tokens)
+}
+
+func (b scopedFleetBudget) Spend(tokens int) {
+	b.budget.Spend(b.database, tokens)
+}
+
+func TestFleetBudgetReservationsAreAtomicAcrossLLMConsumers(t *testing.T) {
+	const (
+		database  = "noisy-db"
+		consumers = 4
+		tokens    = 4
+		budgetCap = 12
+	)
+
+	var requests atomic.Int32
+	gate := make(chan struct{})
+	var releaseOnce sync.Once
+	timer := time.AfterFunc(250*time.Millisecond, func() {
+		releaseOnce.Do(func() { close(gate) })
+	})
+	t.Cleanup(func() { timer.Stop() })
+
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			if requests.Add(1) == consumers {
+				releaseOnce.Do(func() { close(gate) })
+			}
+			<-gate
+			response := map[string]any{
+				"choices": []map[string]any{{
+					"message": map[string]string{"content": "ok"},
+				}},
+				"usage": map[string]int{"total_tokens": tokens},
+			}
+			if err := json.NewEncoder(w).Encode(response); err != nil {
+				t.Errorf("encode mock LLM response: %v", err)
+			}
+		},
+	))
+	t.Cleanup(server.Close)
+
+	shared := fleet.NewBudget(budgetCap, []string{database})
+	clients := make([]*llm.Client, consumers)
+	for index := range clients {
+		clients[index] = llm.New(&config.LLMConfig{
+			Enabled:          true,
+			Endpoint:         server.URL,
+			APIKey:           "test-key",
+			Model:            "test-model",
+			TimeoutSeconds:   2,
+			TokenBudgetDaily: 1000,
+			CooldownSeconds:  0,
+		}, func(string, string, ...any) {})
+		clients[index].SetBudget(scopedFleetBudget{
+			budget: shared, database: database,
+		})
+	}
+
+	start := make(chan struct{})
+	errors := make(chan error, consumers)
+	var workers sync.WaitGroup
+	for _, client := range clients {
+		workers.Add(1)
+		go func(client *llm.Client) {
+			defer workers.Done()
+			<-start
+			_, _, err := client.Chat(
+				context.Background(), "system", "user", tokens,
+			)
+			errors <- err
+		}(client)
+	}
+	close(start)
+	workers.Wait()
+	close(errors)
+
+	successes := 0
+	rejections := 0
+	for err := range errors {
+		switch {
+		case err == nil:
+			successes++
+		case strings.Contains(err.Error(), "per-database token budget exhausted"):
+			rejections++
+		default:
+			t.Errorf("unexpected LLM error: %v", err)
+		}
+	}
+	if successes != 3 || rejections != 1 {
+		t.Fatalf("successes/rejections = %d/%d, want 3/1", successes, rejections)
+	}
+	if got := requests.Load(); got != 3 {
+		t.Errorf("provider requests = %d, want 3", got)
+	}
+	if got := shared.Used(database); got != budgetCap {
+		t.Errorf("recorded spend = %d, want %d", got, budgetCap)
+	}
+}
+
+func TestFleetBudgetReservationReleasedAfterProviderFailure(t *testing.T) {
+	const database = "retry-db"
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "provider unavailable", http.StatusServiceUnavailable)
+		},
+	))
+	t.Cleanup(server.Close)
+
+	budget := fleet.NewBudget(4, []string{database})
+	client := newScopedBudgetClient(server.URL, budget, database)
+	_, _, err := client.Chat(context.Background(), "system", "failure", 4)
+	if err == nil {
+		t.Fatal("provider failure returned nil error")
+	}
+	if got := budget.Used(database); got != 0 {
+		t.Fatalf("failed request retained %d reserved tokens, want 0", got)
+	}
+}
+
+func TestFleetBudgetReconcilesReservationToActualUsage(t *testing.T) {
+	const database = "reconcile-db"
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			response := map[string]any{
+				"choices": []map[string]any{{
+					"message": map[string]string{"content": "ok"},
+				}},
+				"usage": map[string]int{"total_tokens": 2},
+			}
+			if err := json.NewEncoder(w).Encode(response); err != nil {
+				t.Errorf("encode mock LLM response: %v", err)
+			}
+		},
+	))
+	t.Cleanup(server.Close)
+
+	budget := fleet.NewBudget(4, []string{database})
+	client := newScopedBudgetClient(server.URL, budget, database)
+	if _, _, err := client.Chat(
+		context.Background(), "system", "first", 4,
+	); err != nil {
+		t.Fatalf("first request: %v", err)
+	}
+	if got := budget.Used(database); got != 2 {
+		t.Fatalf("actual spend = %d, want 2", got)
+	}
+	if _, _, err := client.Chat(
+		context.Background(), "system", "second", 2,
+	); err != nil {
+		t.Fatalf("reconciled capacity was not reusable: %v", err)
+	}
+}
+
+func newScopedBudgetClient(
+	endpoint string,
+	budget *fleet.FleetBudget,
+	database string,
+) *llm.Client {
+	client := llm.New(&config.LLMConfig{
+		Enabled:          true,
+		Endpoint:         endpoint,
+		APIKey:           "test-key",
+		Model:            "test-model",
+		TimeoutSeconds:   2,
+		TokenBudgetDaily: 1000,
+	}, func(string, string, ...any) {})
+	client.SetBudget(scopedFleetBudget{budget: budget, database: database})
+	return client
+}
+
+// Nil/empty/zero budget behavior is covered by internal/llm/budget_fleet_test.go
+// and internal/fleet/budget_test.go. Provider error propagation is orthogonal:
+// this test isolates concurrent reservation correctness before provider I/O.

--- a/sidecar/internal/llm/client.go
+++ b/sidecar/internal/llm/client.go
@@ -36,11 +36,10 @@ type Client struct {
 	// called concurrently from per-database analyzers/optimizers/advisors
 	// (C1); budgetResetDay was previously a plain int raced against the
 	// atomic counter.
-	tokensUsedToday  atomic.Int64
-	budgetResetDay   atomic.Int64
-	budgetMu         sync.Mutex
-	reservedTokens   int64
-	reservedExternal int
+	tokensUsedToday atomic.Int64
+	budgetResetDay  atomic.Int64
+	budgetMu        sync.Mutex
+	reservedTokens  int64
 
 	// budget is an optional external token budget (e.g. a per-database
 	// allocation in fleet mode), enforced in addition to the daily
@@ -57,6 +56,8 @@ type Client struct {
 // DB can't drain the whole token budget (F5). nil disables it.
 type Budgeter interface {
 	CanSpend(tokens int) bool
+	// Spend applies a usage delta. Negative deltas release a reservation
+	// after a request fails or uses fewer tokens than estimated.
 	Spend(tokens int)
 }
 
@@ -137,7 +138,12 @@ func (c *Client) IsCircuitOpen() bool {
 }
 
 // Chat sends a chat completion request.
-func (c *Client) Chat(ctx context.Context, system, user string, maxTokens int) (string, int, error) {
+func (c *Client) Chat(
+	ctx context.Context,
+	system string,
+	user string,
+	maxTokens int,
+) (string, int, error) {
 	requestCtx, cfg, generation, finish := c.beginRequest(ctx)
 	defer finish()
 	if !configEnabled(cfg) {
@@ -147,7 +153,7 @@ func (c *Client) Chat(ctx context.Context, system, user string, maxTokens int) (
 		return "", 0, fmt.Errorf("LLM circuit breaker open")
 	}
 	maxTokens = normalizedMaxTokens(cfg.Model, maxTokens)
-	throttleKey := requestThrottleKey(cfg)
+	throttleKey := requestThrottleKey(cfg, system, user)
 	if err := c.acquireThrottle(throttleKey, cfg.CooldownSeconds); err != nil {
 		return "", 0, err
 	}
@@ -200,7 +206,7 @@ func (c *Client) Chat(ctx context.Context, system, user string, maxTokens int) (
 
 	resp, err := c.doWithRetry(requestCtx, httpReq, body, cfg.APIKey)
 	if err != nil {
-		if requestCtx.Err() == nil {
+		if shouldRecordProviderFailure(ctx, requestCtx) {
 			c.recordFailure()
 		}
 		return "", 0, providerRequestError("LLM request", err)
@@ -253,6 +259,19 @@ func (c *Client) Chat(ctx context.Context, system, user string, maxTokens int) (
 	}
 
 	return content, tokens, nil
+}
+
+func shouldRecordProviderFailure(
+	callerCtx context.Context,
+	requestCtx context.Context,
+) bool {
+	if requestCtx.Err() == nil {
+		return true
+	}
+	if callerCtx != nil && callerCtx.Err() != nil {
+		return false
+	}
+	return requestCtx.Err() == context.DeadlineExceeded
 }
 
 func (c *Client) doWithRetry(
@@ -392,7 +411,6 @@ func (c *Client) ResetBudget() {
 	defer c.budgetMu.Unlock()
 	c.tokensUsedToday.Store(0)
 	c.reservedTokens = 0
-	c.reservedExternal = 0
 	c.budgetResetDay.Store(int64(time.Now().YearDay()))
 }
 

--- a/sidecar/internal/llm/client_controls.go
+++ b/sidecar/internal/llm/client_controls.go
@@ -4,12 +4,24 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pg-sage/sidecar/internal/config"
 )
+
+// externalBudgetMu makes reservation and reconciliation atomic across distinct
+// Client instances that share one fleet budget. Per-client budgetMu cannot
+// provide that guarantee because fleet mode intentionally builds one client per
+// database and purpose.
+var externalBudgetMu sync.Mutex
+
+// ErrRequestCooldown identifies local duplicate suppression. Callers can use
+// errors.Is to avoid treating admission control as a provider failure.
+var ErrRequestCooldown = errors.New("LLM request cooldown active")
 
 type budgetReservation struct {
 	tokens   int
@@ -103,12 +115,14 @@ func (c *Client) Reconfigure(next *config.LLMConfig) {
 	c.mu.Unlock()
 }
 
-func requestThrottleKey(cfg config.LLMConfig) string {
+func requestThrottleKey(cfg config.LLMConfig, system, user string) string {
 	credential := sha256.Sum256([]byte(cfg.APIKey))
+	workItem := sha256.Sum256([]byte(system + "\x00" + user))
 	return strings.Join([]string{
 		strings.TrimRight(cfg.Endpoint, "/"),
 		cfg.Model,
 		hex.EncodeToString(credential[:8]),
+		hex.EncodeToString(workItem[:16]),
 	}, "|")
 }
 
@@ -119,11 +133,11 @@ func (c *Client) acquireThrottle(key string, cooldownSeconds int) error {
 	c.throttleMu.Lock()
 	defer c.throttleMu.Unlock()
 	if _, active := c.activeKeys[key]; active {
-		return fmt.Errorf("LLM request cooldown active for model key")
+		return fmt.Errorf("%w for work item", ErrRequestCooldown)
 	}
 	cooldown := time.Duration(cooldownSeconds) * time.Second
 	if last := c.lastCalls[key]; !last.IsZero() && time.Since(last) < cooldown {
-		return fmt.Errorf("LLM request cooldown active for model key")
+		return fmt.Errorf("%w for work item", ErrRequestCooldown)
 	}
 	c.activeKeys[key] = struct{}{}
 	return nil
@@ -151,7 +165,6 @@ func (c *Client) reserveBudget(
 	if today != c.budgetResetDay.Load() {
 		c.tokensUsedToday.Store(0)
 		c.reservedTokens = 0
-		c.reservedExternal = 0
 		c.budgetResetDay.Store(today)
 	}
 	used := c.tokensUsedToday.Load()
@@ -167,13 +180,21 @@ func (c *Client) reserveBudget(
 			used+c.reservedTokens, cfg.TokenBudgetDaily,
 		)
 	}
-	if c.budget != nil && !c.budget.CanSpend(tokens+c.reservedExternal) {
-		return budgetReservation{}, fmt.Errorf("per-database token budget exhausted")
-	}
 	c.reservedTokens += int64(tokens)
 	reservation := budgetReservation{tokens: tokens}
 	if c.budget != nil {
-		c.reservedExternal += tokens
+		externalBudgetMu.Lock()
+		if !c.budget.CanSpend(tokens) {
+			externalBudgetMu.Unlock()
+			c.reservedTokens -= int64(tokens)
+			return budgetReservation{}, fmt.Errorf(
+				"per-database token budget exhausted",
+			)
+		}
+		// Charge the estimate as a reservation before provider I/O. A failed
+		// request releases it; a completed request reconciles it to actual use.
+		c.budget.Spend(tokens)
+		externalBudgetMu.Unlock()
 		reservation.external = tokens
 	}
 	return reservation, nil
@@ -183,16 +204,21 @@ func (c *Client) releaseBudget(reservation budgetReservation) {
 	c.budgetMu.Lock()
 	defer c.budgetMu.Unlock()
 	c.reservedTokens -= int64(reservation.tokens)
-	c.reservedExternal -= reservation.external
+	if c.budget != nil && reservation.external > 0 {
+		externalBudgetMu.Lock()
+		c.budget.Spend(-reservation.external)
+		externalBudgetMu.Unlock()
+	}
 }
 
 func (c *Client) reconcileBudget(reservation budgetReservation, actual int) {
 	c.budgetMu.Lock()
 	defer c.budgetMu.Unlock()
 	c.reservedTokens -= int64(reservation.tokens)
-	c.reservedExternal -= reservation.external
 	c.tokensUsedToday.Add(int64(actual))
 	if c.budget != nil {
-		c.budget.Spend(actual)
+		externalBudgetMu.Lock()
+		c.budget.Spend(actual - reservation.external)
+		externalBudgetMu.Unlock()
 	}
 }

--- a/sidecar/internal/llm/models.go
+++ b/sidecar/internal/llm/models.go
@@ -74,11 +74,29 @@ func (c *modelCache) setFor(key string, models []ModelInfo) {
 func ListModels(
 	ctx context.Context, endpoint, apiKey string,
 ) ([]ModelInfo, error) {
+	return ListModelsWithClient(
+		ctx, endpoint, apiKey, http.DefaultClient,
+	)
+}
+
+// ListModelsWithClient queries models with a caller-controlled HTTP client.
+// Security-sensitive callers use this to pin validated DNS resolutions.
+func ListModelsWithClient(
+	ctx context.Context,
+	endpoint string,
+	apiKey string,
+	httpClient *http.Client,
+) ([]ModelInfo, error) {
+	if httpClient == nil {
+		return nil, fmt.Errorf("HTTP client is required")
+	}
 	key := modelCacheKey(endpoint, apiKey)
 	if cached, ok := defaultCache.getFor(key); ok {
 		return cached, nil
 	}
-	models, err := fetchModels(ctx, endpoint, apiKey)
+	models, err := fetchModelsWithClient(
+		ctx, endpoint, apiKey, httpClient,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -99,14 +117,18 @@ func modelCacheKey(endpoint, apiKey string) string {
 		fmt.Sprintf("%x", digest[:16])
 }
 
-// fetchModels dispatches to the correct provider parser.
-func fetchModels(
-	ctx context.Context, endpoint, apiKey string,
+func fetchModelsWithClient(
+	ctx context.Context,
+	endpoint string,
+	apiKey string,
+	httpClient *http.Client,
 ) ([]ModelInfo, error) {
 	if isGeminiEndpoint(endpoint) {
-		return fetchGeminiModels(ctx, apiKey)
+		return fetchGeminiModelsWithClient(ctx, apiKey, httpClient)
 	}
-	return fetchOpenAIModels(ctx, endpoint, apiKey)
+	return fetchOpenAIModelsWithClient(
+		ctx, endpoint, apiKey, httpClient,
+	)
 }
 
 func isGeminiEndpoint(endpoint string) bool {
@@ -114,13 +136,14 @@ func isGeminiEndpoint(endpoint string) bool {
 		endpoint, "generativelanguage.googleapis.com")
 }
 
-// fetchGeminiModels calls the Gemini ListModels API.
-func fetchGeminiModels(
-	ctx context.Context, apiKey string,
+func fetchGeminiModelsWithClient(
+	ctx context.Context,
+	apiKey string,
+	httpClient *http.Client,
 ) ([]ModelInfo, error) {
 	url := "https://generativelanguage.googleapis.com/" +
 		"v1beta/models?key=" + apiKey
-	body, err := doModelRequest(ctx, url, "")
+	body, err := doModelRequestWithClient(ctx, url, "", httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("gemini list models: %w", err)
 	}
@@ -179,12 +202,23 @@ func stripModelsPrefix(name string) string {
 func fetchOpenAIModels(
 	ctx context.Context, endpoint, apiKey string,
 ) ([]ModelInfo, error) {
+	return fetchOpenAIModelsWithClient(
+		ctx, endpoint, apiKey, http.DefaultClient,
+	)
+}
+
+func fetchOpenAIModelsWithClient(
+	ctx context.Context,
+	endpoint string,
+	apiKey string,
+	httpClient *http.Client,
+) ([]ModelInfo, error) {
 	base := strings.TrimRight(endpoint, "/")
 	// Strip chat/completions suffixes to get the base URL.
 	base = strings.TrimSuffix(base, "/chat/completions")
 	base = strings.TrimSuffix(base, "/chat")
 	url := base + "/models"
-	body, err := doModelRequest(ctx, url, apiKey)
+	body, err := doModelRequestWithClient(ctx, url, apiKey, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("openai list models: %w", err)
 	}
@@ -220,6 +254,17 @@ func parseOpenAIModels(data []byte) ([]ModelInfo, error) {
 func doModelRequest(
 	ctx context.Context, url, apiKey string,
 ) ([]byte, error) {
+	return doModelRequestWithClient(
+		ctx, url, apiKey, http.DefaultClient,
+	)
+}
+
+func doModelRequestWithClient(
+	ctx context.Context,
+	url string,
+	apiKey string,
+	httpClient *http.Client,
+) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
@@ -233,7 +278,7 @@ func doModelRequest(
 			"Authorization", "Bearer "+apiKey)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, providerRequestError("http request", err)
 	}

--- a/sidecar/internal/optimizer/audit_admission_failure_test.go
+++ b/sidecar/internal/optimizer/audit_admission_failure_test.go
@@ -1,0 +1,52 @@
+package optimizer
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/pg-sage/sidecar/internal/llm"
+)
+
+func TestAuditAdmissionRejectionDoesNotTripTableCircuit(t *testing.T) {
+	breaker := NewCircuitBreaker()
+	err := fmt.Errorf("llm chat: %w", llm.ErrRequestCooldown)
+	for range 10 {
+		if shouldTripTableCircuit(err) {
+			breaker.RecordFailure("public", "orders")
+		}
+	}
+	if state := breaker.GetState("public", "orders"); state != CircuitClosed {
+		t.Fatalf("admission-only cooldown changed circuit to %s", state)
+	}
+}
+
+func TestAuditProviderFailuresStillTripTableCircuit(t *testing.T) {
+	breaker := NewCircuitBreaker()
+	providerErr := errors.New("provider returned 503")
+	for range 3 {
+		if shouldTripTableCircuit(providerErr) {
+			breaker.RecordFailure("public", "orders")
+		}
+	}
+	if state := breaker.GetState("public", "orders"); state != CircuitOpen {
+		t.Fatalf("provider failures left circuit %s, want open", state)
+	}
+}
+
+func TestAuditWrappedAdmissionErrorsRemainClassified(t *testing.T) {
+	err := fmt.Errorf("optimizer: %w", fmt.Errorf("llm chat: %w", llm.ErrRequestCooldown))
+	if shouldTripTableCircuit(err) {
+		t.Fatal("wrapped admission error was classified as table failure")
+	}
+}
+
+func TestAuditNilErrorDoesNotTripTableCircuit(t *testing.T) {
+	if shouldTripTableCircuit(nil) {
+		t.Fatal("nil error was classified as table failure")
+	}
+}
+
+// Concurrent state mutation is already covered by circuitbreaker_test.go.
+// This file tests the boundary between LLM admission and that synchronized
+// state. No database integration applies because classification is pure.

--- a/sidecar/internal/optimizer/optimizer.go
+++ b/sidecar/internal/optimizer/optimizer.go
@@ -9,6 +9,7 @@ package optimizer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -163,7 +164,9 @@ func (o *Optimizer) Analyze(
 			o.logFn("optimizer",
 				"table %s.%s: %v", tc.Schema, tc.Table, err,
 			)
-			o.breaker.RecordFailure(tc.Schema, tc.Table)
+			if shouldTripTableCircuit(err) {
+				o.breaker.RecordFailure(tc.Schema, tc.Table)
+			}
 			continue
 		}
 		if len(recs) > 0 {
@@ -174,6 +177,10 @@ func (o *Optimizer) Analyze(
 		result.Recommendations = append(result.Recommendations, recs...)
 	}
 	return result, nil
+}
+
+func shouldTripTableCircuit(err error) bool {
+	return err != nil && !errors.Is(err, llm.ErrRequestCooldown)
 }
 
 func (o *Optimizer) analyzeTable(


### PR DESCRIPTION
﻿## Summary

Closes all ten correctness and safety findings from the pg_sage audit and prepares patch release v1.3.1.

- secure the LLM models endpoint against unauthorized access and arbitrary-host SSRF
- account for provider timeouts in breaker state and enforce atomic per-database LLM budgets
- fix fleet health history, ANALYZE concurrency, AgentDB collector lifetime, and meta-mode LLM initialization
- make executor policy hot reload race-safe and honor cron maintenance windows
- apply collector timeouts consistently and preserve parameterized EXPLAIN capture
- document the ReAct boundary and update the changelog

## Root cause and impact

The findings crossed runtime lifecycle, concurrency, admission control, query capture, and API trust boundaries. Left unresolved, they could cause security exposure, incorrect fleet behavior, budget overruns, missed analysis data, or unsafe scheduling decisions.

## Verification

- Full uncached Go suite against isolated PostgreSQL 17: 4,782 passed, 0 failed, 13 explicitly justified skips
- Logical-replication skipped scenario rerun independently: passed
- Go business-logic packages meet the 70% coverage floor; the existing composition-root package remains at 14.3%
- `go build ./...`: pass
- `go vet ./...`: pass
- golangci-lint v2.11.4: 0 issues
- Linux Go 1.24 race tests for executor hot reload, LLM concurrency/budget, and fleet: pass
- Web Vitest: 56 passed
- Web ESLint: pass
- Web Vite production build: pass (existing bundle-size warning only)
