### PR TITLE
fix(lint): resolve golangci-lint findings from v1.4.0

### DIFF
--- a/sidecar/cmd/pg_sage_sidecar/rollout_runtime.go
+++ b/sidecar/cmd/pg_sage_sidecar/rollout_runtime.go
@@ -15,12 +15,6 @@ var fleetRolloutFactoryState struct {
 	factory rollout.RuntimeFactory
 }
 
-func setFleetRolloutRuntimeFactory(factory rollout.RuntimeFactory) {
-	fleetRolloutFactoryState.Lock()
-	defer fleetRolloutFactoryState.Unlock()
-	fleetRolloutFactoryState.factory = factory
-}
-
 func currentFleetRolloutRuntime(ctx context.Context) (*rollout.Runtime, error) {
 	fleetRolloutFactoryState.RLock()
 	factory := fleetRolloutFactoryState.factory

--- a/sidecar/internal/autonomy/freeze_postgres.go
+++ b/sidecar/internal/autonomy/freeze_postgres.go
@@ -104,10 +104,10 @@ func freezeResponseProposal(
 	deadline freeze.Proposal, response freeze.Response,
 ) Proposal {
 	feature := "freeze"
-	if response.Kind == freeze.ResponseCancelBlocker ||
-		response.Kind == freeze.ResponseTerminateBlocker {
+	switch response.Kind {
+	case freeze.ResponseCancelBlocker, freeze.ResponseTerminateBlocker:
 		feature = "freeze_blocker"
-	} else if response.Kind == freeze.ResponseTuneAutovacuum {
+	case freeze.ResponseTuneAutovacuum:
 		feature = "autovacuum_tuning"
 	}
 	evidence := response.Evidence

--- a/sidecar/internal/clone/dle_provider.go
+++ b/sidecar/internal/clone/dle_provider.go
@@ -58,7 +58,7 @@ func (p *DLEProvider) Create(ctx context.Context, spec CloneSpec) (Clone, error)
 	if err != nil {
 		return Clone{}, fmt.Errorf("DLE create request: %w", err)
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != http.StatusCreated {
 		return Clone{}, fmt.Errorf("DLE create failed with status %d", response.StatusCode)
 	}
@@ -96,7 +96,7 @@ func (p *DLEProvider) Destroy(ctx context.Context, target Clone) error {
 	if err != nil {
 		return fmt.Errorf("DLE destroy request: %w", err)
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != http.StatusNoContent && response.StatusCode != http.StatusOK {
 		return fmt.Errorf("DLE destroy failed with status %d", response.StatusCode)
 	}
@@ -112,7 +112,7 @@ func (p *DLEProvider) SnapshotAge(ctx context.Context) (time.Duration, error) {
 	if err != nil {
 		return 0, fmt.Errorf("DLE snapshot request: %w", err)
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode != http.StatusOK {
 		return 0, fmt.Errorf("DLE snapshot failed with status %d", response.StatusCode)
 	}

--- a/sidecar/internal/mcp/runtime.go
+++ b/sidecar/internal/mcp/runtime.go
@@ -51,7 +51,7 @@ func (r *Runtime) Serve(ctx context.Context) error {
 	}
 	scanner := bufio.NewScanner(r.input)
 	writer := bufio.NewWriter(r.output)
-	defer writer.Flush()
+	defer func() { _ = writer.Flush() }()
 	for scanner.Scan() {
 		if err := ctx.Err(); err != nil {
 			return err

--- a/sidecar/internal/policy/store.go
+++ b/sidecar/internal/policy/store.go
@@ -101,7 +101,7 @@ func (s *Store) Ratify(
 	if err != nil {
 		return Policy{}, fmt.Errorf("begin policy ratification: %w", err)
 	}
-	defer tx.Rollback(ctx)
+	defer func() { _ = tx.Rollback(ctx) }()
 	policy, err := ratifyInTransaction(ctx, tx, request)
 	if err != nil {
 		return Policy{}, err

--- a/sidecar/internal/policy/store_test.go
+++ b/sidecar/internal/policy/store_test.go
@@ -295,21 +295,6 @@ func profileJSON(t *testing.T, document Document) string {
 	return string(raw)
 }
 
-func unattendedDocument() string {
-	return `{
-		"allowed_change_classes":["index","analyze","vacuum","freeze"],
-		"maintenance_windows":["always"],
-		"lock_duration_ceiling_ms":3000,
-		"blast_radius":{"max_rows_rewritten":5000000,"max_tables_per_window":20},
-		"unknown_classification":"fail_closed",
-		"budgets":{"storage_bytes":0,"spend_daily":null,"llm_tokens_daily":500000},
-		"rate_limits":{"max_self_initiated_changes_per_window":50},
-		"deadline_overrides":{"xid":true,"disk":true},
-		"refusal_set":["rls_change","grant_expansion"],
-		"serialize_mode":"park"
-	}`
-}
-
 func staffedDocument() string {
 	return `{
 		"allowed_change_classes":["index","analyze","vacuum","freeze"],


### PR DESCRIPTION
Fixes the 8 golangci-lint findings that failed the Test workflow's lint job on master after #45:

- errcheck: deferred `response.Body.Close()` (clone/dle_provider ×3), `writer.Flush()` (mcp/runtime), `tx.Rollback` (policy/store)
- staticcheck QF1003: tagged switch on freeze response kind
- unused: deleted `setFleetRolloutRuntimeFactory` and `unattendedDocument`

Verified locally with CI's exact linter (`golangci-lint v2.11.4`): **0 issues**. Touched packages re-tested green against the test database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)